### PR TITLE
Only access peer arg if mode is set to "peer"

### DIFF
--- a/src/bin/dzd.rs
+++ b/src/bin/dzd.rs
@@ -41,8 +41,8 @@ fn parse_args() -> (Properties, String) {
     config.insert("ZN_LOCAL_ROUTING_KEY".into(), "false".into());
     config.insert("ZN_MODE_KEY".into(), args.value_of("mode").unwrap().into());
 
-    match args.value_of("mode").unwrap() {
-        "peer" => {
+    match args.value_of("mode") {
+        Some("peer") => {
             config.insert("ZN_PEER_KEY".into(), args.value_of("peer").unwrap().into());
         }
         _ => {}

--- a/src/bin/dzd.rs
+++ b/src/bin/dzd.rs
@@ -42,10 +42,11 @@ fn parse_args() -> (Properties, String) {
     config.insert("ZN_MODE_KEY".into(), args.value_of("mode").unwrap().into());
 
     match args.value_of("mode").unwrap() {
-        "peer" => { config.insert("ZN_PEER_KEY".into(), args.value_of("peer").unwrap().into()); },
-        _ => {},
+        "peer" => {
+            config.insert("ZN_PEER_KEY".into(), args.value_of("peer").unwrap().into());
+        }
+        _ => {}
     }
-    
     (config, scope)
 }
 

--- a/src/bin/dzd.rs
+++ b/src/bin/dzd.rs
@@ -40,8 +40,12 @@ fn parse_args() -> (Properties, String) {
     let mut config: Properties = Properties::default();
     config.insert("ZN_LOCAL_ROUTING_KEY".into(), "false".into());
     config.insert("ZN_MODE_KEY".into(), args.value_of("mode").unwrap().into());
-    config.insert("ZN_PEER_KEY".into(), args.value_of("peer").unwrap().into());
 
+    match args.value_of("mode").unwrap() {
+        "peer" => { config.insert("ZN_PEER_KEY".into(), args.value_of("peer").unwrap().into()); },
+        _ => {},
+    }
+    
     (config, scope)
 }
 


### PR DESCRIPTION
Running dzd with the default command line options leads to a panic
```
$ RUST_BACKTRACE=1 LD_LIBRARY_PATH=/usr/local/lib/ ./target/release/dzd 
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/bin/dzd.rs:43:63
stack backtrace:
   0: rust_begin_unwind
             at /rustc/1c389ffeff814726dec325f0f2b0c99107df2673/library/std/src/panicking.rs:493:5
   1: core::panicking::panic_fmt
             at /rustc/1c389ffeff814726dec325f0f2b0c99107df2673/library/core/src/panicking.rs:92:14
   2: core::panicking::panic
             at /rustc/1c389ffeff814726dec325f0f2b0c99107df2673/library/core/src/panicking.rs:50:5
   3: dzd::main::main::{{closure}}
   4: dzd::main
```
due to the line
```rust
config.insert("ZN_PEER_KEY".into(), args.value_of("peer").unwrap().into());
```
as `args.value_of("peer")` returns None, since mode defaults to "client".

This PR adds a simple check to prevent access of the peer arg, unless mode is set to "peer".

_Disclaimer: I'm a very novice Rustacean, so there is likely a better way to do this check_ :slightly_smiling_face: 