### PR TITLE
Add note to README to use Rust nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ In order to get running with the DDS plugin for zenoh you need first to install 
 - [CMake](https://cmake.org/download/)
 - Your favourite C/C++ Compiler
 - [Rust](https://www.rust-lang.org/tools/install)
+  - Rust nightly is currently required. Once initial Rust setup is finished via rustup, install nightly:
+  - ```
+    rustup install nightly
+    ```
 
 Once these dependencies are in place, simply do:
 
@@ -47,7 +51,7 @@ Once these dependencies are in place, simply do:
 $ git clone https://github.com/eclipse-zenoh/zenoh-plugin-dds.git
 $ cd zenoh-plugin-dds
 $ ./config.sh
-$ cargo build --release --all-targets
+$ cargo +nightly build --release --all-targets
 ```
 
 Assuming you want to try this with ROS2, then install it by following the instructions available [here](https://index.ros.org/doc/ros2/Installation/Foxy/).


### PR DESCRIPTION
The current build instructions fail if using the default stable release of Rust installed by rustup due to the use of some unstable features:
```
error[E0554]: `#![feature]` may not be used on the stable release channel
  --> /home/spiderkeys/.cargo/git/checkouts/zenoh-cc237f2570fab813/12bfe92/zenoh-router/src/lib.rs:14:1
   |
14 | #![feature(get_mut_unchecked)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0554]: `#![feature]` may not be used on the stable release channel
  --> /home/spiderkeys/.cargo/git/checkouts/zenoh-cc237f2570fab813/12bfe92/zenoh-router/src/lib.rs:15:1
   |
15 | #![feature(async_closure)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0554]: `#![feature]` may not be used on the stable release channel
  --> /home/spiderkeys/.cargo/git/checkouts/zenoh-cc237f2570fab813/12bfe92/zenoh-router/src/lib.rs:16:1
   |
16 | #![feature(map_into_keys_values)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: aborting due to 3 previous errors

For more information about this error, try `rustc --explain E0554`.
error: could not compile `zenoh-router`

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: build failed
```
This PR updates the README to include instructions for installing nightly and using it to build.