### PR TITLE
Add REST API and admin space

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2844,9 +2844,12 @@ dependencies = [
  "cyclors",
  "env_logger",
  "futures",
+ "hex",
  "libc",
  "log 0.4.14",
  "regex",
+ "serde",
+ "serde_json",
  "zenoh",
  "zenoh-plugin-rest",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,6 +2845,7 @@ dependencies = [
  "env_logger",
  "futures",
  "hex",
+ "lazy_static",
  "libc",
  "log 0.4.14",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,21 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cddc5f91628367664cc7c69714ff08deee8a3efc54623011c772544d7b2767"
+checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+
+[[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-attributes"
@@ -99,6 +111,16 @@ dependencies = [
  "concurrent-queue",
  "event-listener",
  "futures-core",
+]
+
+[[package]]
+name = "async-dup"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7427a12b8dc09291528cfb1da2447059adb4a257388c2acd6497a79d55cf6f7c"
+dependencies = [
+ "futures-io",
+ "simple-mutex",
 ]
 
 [[package]]
@@ -129,6 +151,25 @@ dependencies = [
  "futures-lite",
  "num_cpus",
  "once_cell",
+ "tokio",
+]
+
+[[package]]
+name = "async-h1"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc5142de15b549749cce62923a50714b0d7b77f5090ced141599e78899865451"
+dependencies = [
+ "async-channel",
+ "async-dup",
+ "async-std",
+ "byte-pool",
+ "futures-core",
+ "http-types",
+ "httparse",
+ "lazy_static",
+ "log 0.4.14",
+ "pin-project",
 ]
 
 [[package]]
@@ -193,7 +234,42 @@ checksum = "9c86f33abd5a4f3e2d6d9251a9e0c6a7e52eb1113caf893dae8429bf4a53f378"
 dependencies = [
  "futures-lite",
  "rustls",
- "webpki",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "async-session"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345022a2eed092cd105cc1b26fd61c341e100bd5fcbbd792df4baf31c2cc631f"
+dependencies = [
+ "anyhow",
+ "async-std",
+ "async-trait",
+ "base64 0.12.3",
+ "bincode",
+ "blake3",
+ "chrono",
+ "hmac 0.8.1",
+ "kv-log-macro",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
+name = "async-sse"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53bba003996b8fd22245cd0c59b869ba764188ed435392cf2796d03b805ade10"
+dependencies = [
+ "async-channel",
+ "async-std",
+ "http-types",
+ "log 0.4.14",
+ "memchr",
+ "pin-project-lite 0.1.12",
 ]
 
 [[package]]
@@ -219,7 +295,7 @@ dependencies = [
  "memchr",
  "num_cpus",
  "once_cell",
- "pin-project-lite",
+ "pin-project-lite 0.2.6",
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
@@ -233,9 +309,9 @@ checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
 name = "async-trait"
-version = "0.1.48"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea56748e10732c49404c153638a15ec3d6211ec5ff35d9bb20e13b93576adf"
+checksum = "589652ce7ccb335d1e7ecb3be145425702b290dbcb7029bbeaae263fc1d87b48"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -273,17 +349,22 @@ checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
 
 [[package]]
 name = "base64"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bincode"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d175dfa69e619905c4c3cdb7c3c203fa3bdd5d51184e3afdb2742c0280493772"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "byteorder",
  "serde",
 ]
 
@@ -323,6 +404,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "blake3"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9ff35b701f3914bdb8fad3368d822c766ef2858b2583198e41639b936f09d3f"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if 0.1.10",
+ "constant_time_eq",
+ "crypto-mac 0.8.0",
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,10 +455,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
-name = "byteorder"
-version = "1.3.4"
+name = "byte-pool"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "f8c7230ddbb427b1094d477d821a99f3f54d36333178eeb806e279bcdcecf0ca"
+dependencies = [
+ "crossbeam-queue",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cache-padded"
@@ -396,6 +502,20 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time 0.1.43",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "cipher"
@@ -452,9 +572,15 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
+checksum = "076a6803b0dacd6a88cfe64deba628b01533ff5ef265687e6938280c1afd0a28"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cookie"
@@ -463,15 +589,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
 dependencies = [
  "aes-gcm",
- "base64",
+ "base64 0.13.0",
  "hkdf",
- "hmac",
+ "hmac 0.10.1",
  "percent-encoding",
  "rand 0.8.3",
  "sha2",
- "time",
+ "time 0.2.26",
  "version_check",
 ]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpuid-bool"
@@ -486,6 +628,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +646,16 @@ dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -507,10 +669,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.19"
+name = "ct-logs"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8f45d9ad417bcef4817d614a501ab55cdd96a6fdb24f49aab89a54acfd66b19"
+checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
+dependencies = [
+ "sct",
+]
+
+[[package]]
+name = "ctor"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
 dependencies = [
  "quote",
  "syn",
@@ -534,6 +705,16 @@ dependencies = [
  "bindgen",
  "cmake",
  "libc",
+]
+
+[[package]]
+name = "dashmap"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "num_cpus",
 ]
 
 [[package]]
@@ -607,6 +788,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "femme"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af1a24f391a5a94d756db5092c6576aad494b88a71a5a36b20c67b63e0df034"
+dependencies = [
+ "cfg-if 0.1.10",
+ "js-sys",
+ "log 0.4.14",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,9 +821,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
+checksum = "a9d5813545e459ad3ca1bff9915e9ad7f1a47dc6a91b627ce321d5863b7dd253"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -639,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
+checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -649,15 +846,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
+checksum = "10f6cb7042eda00f0049b1d2080aa4b93442997ee507eb3828e8bd7577f94c9d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -666,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
+checksum = "365a1a1fb30ea1c03a830fdb2158f5236833ac81fa0ad12fe35b29cddc35cb04"
 
 [[package]]
 name = "futures-lite"
@@ -681,15 +878,15 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite",
+ "pin-project-lite 0.2.6",
  "waker-fn",
 ]
 
 [[package]]
 name = "futures-macro"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
+checksum = "668c6733a182cd7deb4f1de7ba3bf2120823835b3bcfbeacf7d2c4a773c1bb8b"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -699,21 +896,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
+checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
 
 [[package]]
 name = "futures-task"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
+checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
 
 [[package]]
 name = "futures-util"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
+checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -722,7 +919,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite",
+ "pin-project-lite 0.2.6",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -846,7 +1043,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51ab2f639c231793c5f6114bdb9bbe50a7dbbfcd7c7c6bd8475dec2d991e964f"
 dependencies = [
  "digest",
- "hmac",
+ "hmac 0.10.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac 0.8.0",
+ "digest",
 ]
 
 [[package]]
@@ -855,7 +1062,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
- "crypto-mac",
+ "crypto-mac 0.10.0",
  "digest",
 ]
 
@@ -869,19 +1076,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-types"
-version = "2.10.0"
+name = "http-client"
+version = "6.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32613ebb139d1d430ef5783676f84abfa06fc5f2b4b5a25220cdeeff7e16ef5c"
+checksum = "5566ecc26bc6b04e773e680d66141fced78e091ad818e420d726c152b05a64ff"
+dependencies = [
+ "async-trait",
+ "cfg-if 1.0.0",
+ "dashmap",
+ "http-types",
+ "log 0.4.14",
+]
+
+[[package]]
+name = "http-types"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f600cccfb9d96c45550bac47b592bc88191a0dd965e9d55848880c2c5a45f"
 dependencies = [
  "anyhow",
  "async-channel",
  "async-std",
- "base64",
+ "base64 0.13.0",
  "cookie",
  "futures-lite",
  "infer",
- "pin-project-lite",
+ "pin-project-lite 0.2.6",
  "rand 0.7.3",
  "serde",
  "serde_json",
@@ -891,6 +1111,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "httparse"
+version = "1.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc35c995b9d93ec174cf9a27d425c7892722101e14993cd227fdb51d70cf9589"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,9 +1124,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "idna"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -949,9 +1175,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.49"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc15e39392125075f60c95ba416f5381ff6c3a948ff02ab12464715adf56c821"
+checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -995,9 +1221,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.91"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
+checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
 
 [[package]]
 name = "libloading"
@@ -1041,13 +1267,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
+name = "mio"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
+dependencies = [
+ "libc",
+ "log 0.4.14",
+ "miow",
+ "ntapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "nb-connect"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19900e7eee95eb2b3c2e26d12a874cc80aaf750e31be6fcbe743ead369fa45d"
 dependencies = [
  "libc",
- "socket2",
+ "socket2 0.4.0",
 ]
 
 [[package]]
@@ -1073,6 +1321,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,6 +1371,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
 name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1387,17 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
+dependencies = [
+ "base64 0.13.0",
+ "once_cell",
+ "regex",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1130,6 +1423,32 @@ dependencies = [
  "fixedbitset",
  "indexmap",
 ]
+
+[[package]]
+name = "pin-project"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc174859768806e91ae575187ada95c91a29e96a98dc5d2cd9a1fed039501ba6"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a490329918e856ed1b083f244e3bfe2d8c4f336407e4ea9e1a9f479ff09049e5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
@@ -1275,9 +1594,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 dependencies = [
  "unicode-xid 0.2.1",
 ]
@@ -1287,6 +1606,45 @@ name = "quick-error"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ac73b1112776fc109b2e61909bc46c7e1bf0d7f690ffb1676553acce16d5cda"
+
+[[package]]
+name = "quinn"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c82c0a393b300104f989f3db8b8637c0d11f7a32a9c214560b47849ba8f119aa"
+dependencies = [
+ "bytes",
+ "futures",
+ "lazy_static",
+ "libc",
+ "mio",
+ "quinn-proto",
+ "rustls",
+ "socket2 0.3.19",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09027365a21874b71e1fbd9d31cb99bff8e11ba81cc9ef2b9425bb607e42d3b2"
+dependencies = [
+ "bytes",
+ "ct-logs",
+ "rand 0.8.3",
+ "ring",
+ "rustls",
+ "rustls-native-certs",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "webpki 0.21.4",
+]
 
 [[package]]
 name = "quote"
@@ -1379,10 +1737,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.5"
+name = "rcgen"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "4e80a701a04edd9cab874a3d59323bebe24c9a92dd602088c78da83732066d1b"
+dependencies = [
+ "chrono",
+ "pem",
+ "ring",
+ "yasna",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8270314b5ccceb518e7e578952f0b72b88222d02e8f77f5ecf7abbb673539041"
 dependencies = [
  "bitflags 1.2.1",
 ]
@@ -1430,6 +1800,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "route-recognizer"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56770675ebc04927ded3e60633437841581c285dc6236109ea25fbf3beb7b59e"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1465,11 +1841,23 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "log 0.4.14",
  "ring",
  "sct",
- "webpki",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1479,13 +1867,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
-name = "sct"
-version = "0.6.0"
+name = "schannel"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3670b1d2fdf6084d192bc71ead7aabe6c06aa2ea3fbd9cc3ac111fa5c2b1bd84"
+dependencies = [
+ "bitflags 1.2.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1523,18 +1944,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
+checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1638,9 +2059,9 @@ checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa894ef3fade0ee7243422f4fbbd6c2b48e6de767e621d37ef65f2310f53cea"
+checksum = "ef33d6d0cd06e0840fba9985aab098c147e67e05cee14d412d3345ed14ff30ac"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -1656,10 +2077,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple-mutex"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38aabbeafa6f6dead8cebf246fe9fae1f9215c8d29b3a69f93bd62a9e4a3dcd6"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
+name = "socket2"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "socket2"
@@ -1676,6 +2117,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "standback"
@@ -1748,10 +2195,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
-name = "syn"
-version = "1.0.64"
+name = "sval"
+version = "1.0.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd9d1e9976102a03c542daa2eff1b43f9d72306342f3f8b3ed5fb8908195d6f"
+checksum = "45f6ee7c7b87caf59549e9fe45d6a69c75c8019e79e212a835c5da0e92f0ba08"
+
+[[package]]
+name = "syn"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fe99c6bd8b1cc636890bcc071842de909d902c81ac7dab53ba33c421ab8ffb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1856,6 +2309,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tide"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c459573f0dd2cc734b539047f57489ea875af8ee950860ded20cf93a79a1dee0"
+dependencies = [
+ "async-h1",
+ "async-session",
+ "async-sse",
+ "async-std",
+ "async-trait",
+ "femme",
+ "futures-util",
+ "http-client",
+ "http-types",
+ "kv-log-macro",
+ "log 0.4.14",
+ "pin-project-lite 0.2.6",
+ "route-recognizer",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "time"
 version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1895,9 +2381,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1907,6 +2393,51 @@ name = "tinyvec_macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "tokio"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
+dependencies = [
+ "autocfg",
+ "libc",
+ "mio",
+ "num_cpus",
+ "pin-project-lite 0.2.6",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "pin-project-lite 0.2.6",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+dependencies = [
+ "lazy_static",
+]
 
 [[package]]
 name = "typenum"
@@ -1935,9 +2466,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
 dependencies = [
  "matches",
 ]
@@ -2014,6 +2545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b676010e055c99033117c2343b33a40a30b91fecd6c49055ac9cd2d6c305ab1"
 dependencies = [
  "ctor",
+ "sval",
 ]
 
 [[package]]
@@ -2054,19 +2586,21 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe8f61dba8e5d645a4d8132dc7a0a66861ed5e1045d2c0ed940fab33bac0fbe"
+checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
 dependencies = [
  "cfg-if 1.0.0",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ceba58ff062da072c7cb4ba5b22a37f00a302483f7e2a6cdc18fedbdc1fd3"
+checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2079,9 +2613,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73157efb9af26fb564bb59a009afd1c7c334a44db171d280690d0c3faaec3468"
+checksum = "81b8b767af23de6ac18bf2168b690bed2902743ddf0fb39252e36f9e2bfc63ea"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -2091,9 +2625,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9aa01d36cda046f797c57959ff5f3c615c9cc63997a8d545831ec7976819b"
+checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2101,9 +2635,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eb45c1b2ee33545a813a92dbb53856418bf7eb54ab34f7f7ff1448a5b3735d"
+checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2114,15 +2648,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7148f4696fb4960a346eaa60bbfb42a1ac4ebba21f750f75fc1375b098d5ffa"
+checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
 
 [[package]]
 name = "web-sys"
-version = "0.3.49"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fe19d70f5dacc03f6e46777213facae5ac3801575d56ca6cbd4c93dcd12310"
+checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2133,6 +2667,16 @@ name = "webpki"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
  "ring",
  "untrusted",
@@ -2200,14 +2744,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "yasna"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de7bff972b4f2a06c85f6d8454b09df153af7e3a4ec2aac81db1b105b684ddb"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
 name = "zenoh"
 version = "0.5.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh#174b5e6a1114ceea7bbaa719446a7682cb5eecb3"
+source = "git+https://github.com/eclipse-zenoh/zenoh#74463624337f38aa0d7caa14b5cbdde7aaa20f95"
 dependencies = [
  "async-rustls",
  "async-std",
  "async-trait",
- "base64",
+ "base64 0.13.0",
  "bincode",
  "clap",
  "env_logger",
@@ -2220,24 +2773,44 @@ dependencies = [
  "log 0.4.14",
  "nix",
  "petgraph",
- "pin-project-lite",
+ "pin-project-lite 0.2.6",
+ "quinn",
  "rand 0.8.3",
+ "rcgen",
  "regex",
  "rustc_version 0.3.3",
  "serde",
  "serde_json",
  "shared_memory",
- "socket2",
+ "socket2 0.4.0",
  "uhlc",
  "uuid",
  "vec_map",
+ "webpki 0.22.0",
  "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-plugin-rest"
+version = "0.5.0-dev"
+source = "git+https://github.com/eclipse-zenoh/zenoh#74463624337f38aa0d7caa14b5cbdde7aaa20f95"
+dependencies = [
+ "async-std",
+ "base64 0.13.0",
+ "clap",
+ "env_logger",
+ "futures",
+ "http-types",
+ "log 0.4.14",
+ "serde_json",
+ "tide",
+ "zenoh",
 ]
 
 [[package]]
 name = "zenoh-util"
 version = "0.5.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh#174b5e6a1114ceea7bbaa719446a7682cb5eecb3"
+source = "git+https://github.com/eclipse-zenoh/zenoh#74463624337f38aa0d7caa14b5cbdde7aaa20f95"
 dependencies = [
  "aes-soft",
  "async-std",
@@ -2246,7 +2819,7 @@ dependencies = [
  "event-listener",
  "futures",
  "hex",
- "hmac",
+ "hmac 0.10.1",
  "home",
  "humantime",
  "lazy_static",
@@ -2275,4 +2848,5 @@ dependencies = [
  "log 0.4.14",
  "regex",
  "zenoh",
+ "zenoh-plugin-rest",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2755,7 +2755,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "0.5.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh#a32ba33953e37992df8b4be068f2cb99d7813947"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4a28777342de1ea3747ec2e1ce95f310644ba0a8"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -2793,7 +2793,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-rest"
 version = "0.5.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh#a32ba33953e37992df8b4be068f2cb99d7813947"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4a28777342de1ea3747ec2e1ce95f310644ba0a8"
 dependencies = [
  "async-std",
  "base64 0.13.0",
@@ -2810,7 +2810,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.5.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh#a32ba33953e37992df8b4be068f2cb99d7813947"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4a28777342de1ea3747ec2e1ce95f310644ba0a8"
 dependencies = [
  "aes-soft",
  "async-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2755,7 +2755,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "0.5.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh#74463624337f38aa0d7caa14b5cbdde7aaa20f95"
+source = "git+https://github.com/eclipse-zenoh/zenoh#a32ba33953e37992df8b4be068f2cb99d7813947"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -2793,7 +2793,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-rest"
 version = "0.5.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh#74463624337f38aa0d7caa14b5cbdde7aaa20f95"
+source = "git+https://github.com/eclipse-zenoh/zenoh#a32ba33953e37992df8b4be068f2cb99d7813947"
 dependencies = [
  "async-std",
  "base64 0.13.0",
@@ -2810,7 +2810,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.5.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh#74463624337f38aa0d7caa14b5cbdde7aaa20f95"
+source = "git+https://github.com/eclipse-zenoh/zenoh#a32ba33953e37992df8b4be068f2cb99d7813947"
 dependencies = [
  "aes-soft",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,10 @@ clap = "2.33"
 env_logger = "0.8.2"
 regex = "1.4.3"
 hex = "0.4.3"
+lazy_static = "1.4.0"
 serde = "1.0.125"
 serde_json = "1.0.64"
+
 
 
 [dependencies.async-std]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,12 @@ description = "Zenoh plugin for ROS2 and DDS in general"
 
 [lib]
 name = "zplugin_dds"
-# crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 
 [dependencies]
 zenoh =  { git = "https://github.com/eclipse-zenoh/zenoh"}
+zenoh-plugin-rest =  { git = "https://github.com/eclipse-zenoh/zenoh"}
 cyclors = "0.1.1"
 log = "0.4.14"
 async-trait = "0.1.42"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,10 @@ libc = "0.2.85"
 clap = "2.33"
 env_logger = "0.8.2"
 regex = "1.4.3"
+hex = "0.4.3"
+serde = "1.0.125"
+serde_json = "1.0.64"
+
 
 [dependencies.async-std]
 version = "1.9.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,13 +25,10 @@ RUN mkdir /usr/share/man/man1/
 #  * for CycloneDDS
 #     - g++
 #     - cmake
-#     - libssl-dev
-#     - openjdk-11-jdk-headless
-#     - maven
 #  * for zenoh-dds-plugin
 #     - git
 #     - clang
-RUN apt-get update && apt-get -y install g++ cmake libssl-dev openjdk-11-jdk-headless maven git clang
+RUN apt-get update && apt-get -y install g++ cmake git clang
 
 COPY . .
 RUN cargo install --path .

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,18 @@ pipeline {
     string(name: 'DOCKER_TAG',
            description: 'An extra Docker tag (e.g. "latest"). By default GIT_TAG will also be used as Docker tag',
            defaultValue: '')
+    booleanParam(name: 'BUILD_MACOSX',
+                 description: 'Build macosx target.',
+                 defaultValue: true)
+    booleanParam(name: 'BUILD_DOCKER',
+                 description: 'Build Docker image.',
+                 defaultValue: true)
+    booleanParam(name: 'BUILD_LINUX64',
+                 description: 'Build x86_64-unknown-linux-gnu target.',
+                 defaultValue: true)
+    booleanParam(name: 'PUBLISH_ECLIPSE_DOWNLOAD',
+                 description: 'Publish the resulting artifacts to Eclipse download.',
+                 defaultValue: false)
     booleanParam(name: 'PUBLISH_DOCKER_HUB',
                  description: 'Publish the resulting artifacts to DockerHub.',
                  defaultValue: false)
@@ -16,6 +28,8 @@ pipeline {
   environment {
       DOCKER_IMAGE="eclipse/zenoh-bridge-dds"
       LABEL = get_label()
+      DOWNLOAD_DIR="/home/data/httpd/download.eclipse.org/zenoh/zenoh-plugin-dds/${LABEL}"
+      MACOSX_DEPLOYMENT_TARGET=10.7
   }
 
   stages {
@@ -34,6 +48,27 @@ pipeline {
       }
     }
 
+    stage('[MacMini] Build and tests') {
+      when { expression { return params.BUILD_MACOSX }}
+      steps {
+        sh '''
+        echo "Building zenoh-plugin-dds-${LABEL}"
+        cargo build --release --all-targets
+        cargo test --release
+        '''
+      }
+    }
+
+    stage('[MacMini] MacOS Package') {
+      when { expression { return params.BUILD_MACOSX }}
+      steps {
+        sh '''
+        tar -czvf zenoh-plugin-dds-${LABEL}-macosx${MACOSX_DEPLOYMENT_TARGET}-x86-64.tgz --strip-components 2 target/release/zenoh-bridge-dds
+        tar -czvf zenoh-bridge-dds-${LABEL}-macosx${MACOSX_DEPLOYMENT_TARGET}-x86-64.tgz --strip-components 2 target/release/libzplugin_dds.so
+        '''
+      }
+    }
+
     stage('[MacMini] Docker build') {
       steps {
         sh '''
@@ -44,6 +79,29 @@ pipeline {
         '''
       }
     }
+
+    stage('[MacMini] x86_64-unknown-linux-gnu build') {
+      when { expression { return params.BUILD_LINUX64 }}
+      steps {
+        sh '''
+        docker run --init --rm -v $(pwd):/workdir -w /workdir adlinktech/zenoh-dev-manylinux2010-x86_64-gnu \
+          /bin/bash -c "\
+            rustup default ${RUST_TOOLCHAIN} && \
+            cargo build --release
+          "
+        '''
+      }
+    }
+    stage('[MacMini] x86_64-unknown-linux-gnu Package') {
+      when { expression { return params.BUILD_LINUX64 }}
+      steps {
+        sh '''
+        tar -czvf zenoh-plugin-dds-${LABEL}-x86_64-unknown-linux-gnu.tgz --strip-components 2 target/x86_64-unknown-linux-gnu/release/zenoh-bridge-dds
+        tar -czvf zenoh-bridge-dds-${LABEL}-x86_64-unknown-linux-gnu.tgz --strip-components 2 target/x86_64-unknown-linux-gnu/release/libzplugin_dds.so
+        '''
+      }
+    }
+
 
     stage('[MacMini] Publish to Docker Hub') {
       when { expression { return params.PUBLISH_DOCKER_HUB }}

--- a/README.md
+++ b/README.md
@@ -4,38 +4,44 @@
 [![License](https://img.shields.io/badge/License-EPL%202.0-blue)](https://choosealicense.com/licenses/epl-2.0/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-# Zenoh plugin for DDS
+# DDS plugin for Eclipse zenoh
 
 ## Background
 The Data Distribution Service (DDS) is a standard for data-centric publish subscribe. Whilst DDS has been around for quite some time and has a long history of deployments in various industries, it has recently gained quite a bit of attentions thanks to its adoption by the Robotic Operating System (ROS2) -- where it is used for communication between ROS2 nodes.
 
 ## Robot Swarms and Edge Robotics
-As mentioned above, ROS2 has adopted DDS as the mechanism to exchange data between nodes within and potentially across a robot. That said, due to some of the very core assumptions at the foundations of the DDS wire-protocol, beside the fact that it  leverage UDP/IP multicast for communication,  it is not so straightforward to scale DDS communication over a WAN or across multiple LANs.  Zenoh, on the other hand was designed since its inception to operate at Internet Scale.
+As mentioned above, ROS2 has adopted DDS as the mechanism to exchange data between nodes within and potentially across a robot. That said, due to some of the very core assumptions at the foundations of the DDS wire-protocol, beside the fact that it leverages UDP/IP multicast for communication, it is not so straightforward to scale DDS communication over a WAN or across multiple LANs. Zenoh, on the other hand was designed since its inception to operate at Internet Scale.
 
 ![zenoh-plugin-dds](http://zenoh.io/img/wiki/zenoh-plugin-dds.png)
 
-Thus, the main motivations to have a **DDS connector** for **zenoh** are:
+Thus, the main motivations to have a **zenoh bridge** for **DDS** are:
 
 - Facilitate the interconnection of robot swarms.
 - Support use cases of edge robotics.
 - Give the possibility to use **zenoh**'s geo-distributed storage and query system to better manage robot's data.
 
 ## Architecture
-**zenoh** routers provide a plug-in mechanism that allow for extensions to be loaded and activated by its management API. Thus the most natural way to implement a DDS connector for zenoh is to do that as a zenoh router plugin.
 
-This plugin, will essentially:
+The **zenoh bridge for DDS** will soon be available as a library that can be loaded by a zenoh router at startup.
 
-- Spoof DDS discovery data and transparently expose DDS writers/readers as zenoh publisher/subscribers
-- Route the data produced by discovered DDS writers to data to matching entities.
+Currently, it's a standalone executable named **`zenoh-bridge-dds`** that:
+- discover the DDS readers and writers declared by any DDS application, via the standard DDS discovery protocol (that uses UDP multicast)
+- create a mirror DDS writer or reader for each discovered reader or writer (using the same QoS)
+- map the discovered DDS topics and partitions to zenoh resources (see mapping details below)
+- forward user's data from a DDS topic to the corresponding zenoh resource, and vice versa
 
-Beside the zenoh router plugin we also support a stand-alone bridge called **zenoh-bridge-dds** that can be used to transparently bridge DDS data on zenoh and viceversa.
+### Routing of DDS discovery information
+:warning: **Important notice** :warning: :  
+The DDS discovery protocol is not routed through zenoh.  
+Meaning that, in case you use 2 **`zenoh-bridge-dds`** to interconnect 2 DDS domains, the DDS entities discovered in one domain won't be advertised in the other domain. Thus, the DDS data will be routed between the 2 domains only if matching readers and writers are declared in the 2 domains independently.
 
-### Mapping DDS to zenoh
-The mapping between DDS and zenoh is rather straightforward. Given a DDS Reader/Writer for topic ```A``` in a given partition ```P``` with a set of QoS ```Q```, then the equivalent zenoh resource will be named as ```P/A/*```. On the other hand actual writes will be on the resource ```/P/A/sample-key-hash``` as this allows for zenoh subscriber to easily subscribe to just a specific Topic instance, a set of them or of all of them.
+### Mapping DDS topics to zenoh resources
+The mapping between DDS and zenoh is rather straightforward. Given a DDS Reader/Writer for topic **`A`** in a given partition **`P`**, then the equivalent zenoh resource will be named as **`/P/A`**. If no partition is defined, the equivalent zenoh resource will be named as **`/A`**.
 
+Optionally, the bridge can be configured with a **scope** that will be used as a prefix to each zenoh resource. That is, for scope **`/S`** the equivalent zenoh resource will be **`/S/P/A`** for a topic **`A`** and a partition **`P`**, and **`/S/A`** for a topic without partition.
 
-## Trying it Out
-In order to get running with the DDS plugin for zenoh you need first to install the following dependencies:
+## How to build it
+In order to build the zenoh bridge for DDS you need first to install the following dependencies:
 
 - [Rust](https://www.rust-lang.org/tools/install)
 - On Linux, make sure the `llvm` and `clang` development packages are installed:
@@ -53,6 +59,7 @@ $ cargo build --release
 ```
 The **zenoh-bridge-dds** binary will be generated in the `target/release` sub-directory.
 
+## How to test it
 Assuming you want to try this with ROS2, then install it by following the instructions available [here](https://index.ros.org/doc/ros2/Installation/Foxy/).
 Once you've installed ROS2, you easily let ROS applications communicate across the internet.
 That said the simplest way to quicky try out the zenoh bridge for DDS is to use it to bridge ROS2/DDS communnication across different ROS2/DDS domains.
@@ -80,6 +87,62 @@ $ ./target/release/zenoh-bridge-dds --scope /demo/dds -m peer -d 42
 ```
 
 Otherwise, just run them on the same machine, you will see a stream of ROS2 *Hello World* messages coming across. Once again, as the ROS2 applications are using different domains, they are unable to discover and communicate, thus the data you see is flowing over zenoh.
+
+### zenoh-bridge-dds command line arguments
+
+`zenoh-dds-bridge` accepts the following arguments:
+ * zenoh-related arguments:
+   - `-m, --mode <MODE>` : The zenoh session mode. Default: `peer` Possible values: `peer` or `client`.  
+      See [zenoh documentation](https://zenoh.io/docs/getting-started/key-concepts/#deployment-units) for more details.
+   - `-l, --listener <LOCATOR>` : The locators the bridge will listen on for zenoh protocol. Can be specified multiple times. Example of locator: `tcp/localhost:7447`.
+   - `-e, --peer <LOCATOR>` : zenoh peers locators the bridge will try to connect to (typically another bridge or a zenoh router). Example of locator: `tcp/<ip-address>:7447`.
+   - `--no-multicast-scouting` : disable the zenoh scouting protocol that allows automatic discovery of zenoh peers and routers.
+   - `--rest-plugin` : activate the [zenoh REST API](https://zenoh.io/docs/apis/apis/#rest-api), available by default on port 8000.
+   - `--rest-http-port <rest-http-port>` : set the REST API http port (default: 8000)
+ * DDS-related arguments:
+   - `-d, --dds-domain <ID>` : The DDS Domain ID (if using with ROS this should be the same as `ROS_DOMAIN_ID`)
+   - `-s, --dds-scope <String>` : A string used as prefix to scope DDS traffic when mapped to zenoh resources.
+   - `-a, --dds-allow <String>`:  A regular expression matching the set of 'partition/topic-name' that should
+     be bridged. By default, all partitions and topic are allowed.  
+     Examples of expressions: 
+        - `.*/TopicA` will allow only the `TopicA` to be routed, whatever the partition.
+        - `PartitionX/.*` will allow all the topics to be routed, but only on `PartitionX`.
+        - `cmd_vel|rosout` will allow only the topics containing `cmd_vel` or `rosout` in their name or partition name to be routed.
+   - `-w, --dds-generalise-pub <String>` :  A list of key expressions to use for generalising the declaration of
+     the zenoh publications, and thus minimizing the discovery traffic (usable multiple times).
+     See [this blog](https://zenoh.io/blog/2021-03-23-discovery/#leveraging-resource-generalisation) for more details.
+   - `-r, --dds-generalise-sub <String>` :  A list of key expressions to use for generalising the declaration of
+     the zenoh subscriptions, and thus minimizing the discovery traffic (usable multiple times).
+     See [this blog](https://zenoh.io/blog/2021-03-23-discovery/#leveraging-resource-generalisation) for more details.
+
+### Admin space
+
+The zenoh bridge for DDS exposes and administration space allowing to browse the DDS entities that have been discovered (with their QoS), and the routes that have been established between DDS and zenoh.
+This administration space is accessible via any zenoh API, including the REST API.
+
+The `zenoh-dds-bridge` exposes this administration space with paths prefixed by `/@/service/<uuid>/dds` (where `<uuid>` is the unique identifier of the bridge instance). The informations are then organized with such paths:
+ - `/@/service/<uuid>/dds/config` : the bridge configuration
+ - `/@/service/<uuid>/dds/participant/<gid>/reader/<gid>/<topic>` : a discovered DDS reader on `<topic>`
+ - `/@/service/<uuid>/dds/participant/<gid>/writer/<gid>/<topic>` : a discovered DDS reader on `<topic>`
+ - `/@/service/<uuid>/dds/route/from_dds/<zenoh-resource>` : a route established from a DDS writer to a zenoh resource named `<zenoh-resource>` (see [mapping rules](#mapping-dds-topics-to-zenoh-resources)).
+ - `/@/service/<uuid>/dds/route/to_dds/<zenoh-resource>` : a route established from a zenoh resource named `<zenoh-resource>` (see [mapping rules](#mapping-dds-topics-to-zenoh-resources))..
+
+Example of queries on administration space using the REST API with the `curl` command line tool
+(don't forget to activate the REST API with `--rest-plugin` argument):
+ - List all the DDS entities that have been discovered:
+    ```bash
+    curl http://localhost:8000:/@/service/**/participant/**
+    ```
+ - List all established routes:
+    ```bash
+    curl http://localhost:8000:/@/service/**/route/**
+    ```
+ - List all discovered DDS entities and established route for topic `cmd_vel`:
+    ```bash
+    curl http://localhost:8000:/@/service/**/cmd_vel
+    ```
+
+> _Pro tip: pipe the result into [**jq**](https://stedolan.github.io/jq/) command for JSON pretty print or transformation._
 
 ### Troubleshooting
 In case you do not see any data flowing around when running  on different computers across a network, it may be due to your network does not allowing for multicast - this latter is used for scouting in zenoh. The simplest way to fix this issue is to explicitely pass locators as described next.

--- a/src/bin/zenoh-bridge-dds.rs
+++ b/src/bin/zenoh-bridge-dds.rs
@@ -118,11 +118,9 @@ async fn main() {
 
     // start REST plugin
     if rest_plugin {
-        zplugin_rest::run(runtime.clone(), args.clone()).await;
+        async_std::task::spawn(zplugin_rest::run(runtime.clone(), args.clone()));
     }
 
     // start DDS plugin
     zplugin_dds::run(runtime.clone(), args.clone()).await;
-
-    future::pending::<()>().await;
 }

--- a/src/bin/zenoh-bridge-dds.rs
+++ b/src/bin/zenoh-bridge-dds.rs
@@ -14,7 +14,6 @@
 #![feature(vec_into_raw_parts)]
 
 use clap::{App, Arg, ArgMatches};
-use futures::prelude::*;
 use zenoh::Properties;
 
 // customize the DDS plugin args for retro-compatibility with previous versions of the standalone bridge

--- a/src/bin/zenoh-bridge-dds.rs
+++ b/src/bin/zenoh-bridge-dds.rs
@@ -13,22 +13,32 @@
 //
 #![feature(vec_into_raw_parts)]
 
-use async_std::task;
-use clap::{App, Arg};
-use cyclors::*;
+use clap::{App, Arg, ArgMatches};
 use futures::prelude::*;
-use log::{debug, info};
-use regex::Regex;
-use std::collections::HashMap;
-use std::ffi::CString;
-use std::sync::mpsc::{channel, Receiver, Sender};
-use std::sync::Arc;
-use zenoh::net::*;
 use zenoh::Properties;
-use zplugin_dds::*;
 
-fn parse_args() -> (Properties, String, u32, Option<Regex>) {
-    let args = App::new("zenoh bridge for DDS")
+// customize the DDS plugin args for retro-compatibility with previous versions of the standalone bridge
+fn customize_dds_args<'a, 'b>(mut args: Vec<Arg<'a, 'b>>) -> Vec<Arg<'a, 'b>> {
+    // NOTE: no way to check what's each Arg is in the Vec!
+    // We need to assume that there are 5, and that they are in correct order...
+    // as specifed in src/lib.rs in get_expected_args()
+    assert_eq!(5, args.len());
+    let arg = args.remove(0).short("s").visible_alias("scope");
+    args.push(arg);
+    let arg = args.remove(0).short("w").visible_alias("generalise-pub");
+    args.push(arg);
+    let arg = args.remove(0).short("r").visible_alias("generalise-sub");
+    args.push(arg);
+    let arg = args.remove(0).short("d").visible_alias("domain");
+    args.push(arg);
+    let arg = args.remove(0).short("a").visible_alias("allow");
+    args.push(arg);
+
+    args
+}
+
+fn parse_args() -> (Properties, bool, ArgMatches<'static>) {
+    let app = App::new("zenoh bridge for DDS")
         .arg(Arg::from_usage(
             "-e, --peer=[LOCATOR]...  'Peer locator used to initiate the zenoh session.'\n",
         ))
@@ -37,15 +47,6 @@ fn parse_args() -> (Properties, String, u32, Option<Regex>) {
         ))
         .arg(Arg::from_usage(
             "-c, --config=[FILE]      'A configuration file.'\n",
-        ))
-        .arg(Arg::from_usage(
-            "-s, --scope=[String]...   'A string used as prefix to scope DDS traffic.'\n",
-        ))
-        .arg(Arg::from_usage(
-            "-w, --generalise-pub=[String]...   'A comma separated list of key expression to use for generalising pubblications.'\n",
-        ))
-        .arg(Arg::from_usage(
-            "-r, --generalise-sub=[String]...   'A comma separated list of key expression to use for generalising subscriptions.'\n",
         ))
         .arg(
             Arg::from_usage("-m, --mode=[MODE]  'The zenoh session mode.'\n")
@@ -60,41 +61,20 @@ fn parse_args() -> (Properties, String, u32, Option<Regex>) {
         )
         .arg(
             Arg::from_usage(
-                "-d, --domain=[ID] 'The DDS Domain ID (if using with ROS this should be the same as ROS_DOMAIN_ID).'\n")
+                "--rest-plugin   'Enable the zenoh REST plugin (disabled by default)'")
         )
-        .arg(
-            Arg::from_usage(
-                "-a, --allow=[String] 'The regular expression describing set of /partition/topic-name that should be bridged, everything is forwarded by default.'\n"
-            )
-        )
-        .get_matches();
+        .args(&zplugin_rest::get_expected_args2()) // add REST plugin expected args
+        .args(&customize_dds_args(zplugin_dds::get_expected_args2()));
 
-    let scope: String = args
-        .value_of("scope")
-        .map(String::from)
-        .or_else(|| Some(String::from("")))
-        .unwrap();
+    let args = app.get_matches();
 
     let mut config: Properties = if let Some(conf_file) = args.value_of("config") {
         Properties::from(std::fs::read_to_string(conf_file).unwrap())
     } else {
         Properties::default()
     };
-    config.insert("local_routing".into(), "false".into());
     config.insert("mode".into(), args.value_of("mode").unwrap().into());
 
-    if let Some(value) = args.values_of("generalise-sub") {
-        config.insert(
-            "join_subscriptions".into(),
-            value.collect::<Vec<&str>>().join(","),
-        );
-    }
-    if let Some(value) = args.values_of("generalise-pub") {
-        config.insert(
-            "join_publications".into(),
-            value.collect::<Vec<&str>>().join(","),
-        );
-    }
     if let Some(value) = args.values_of("peer") {
         config.insert("peer".into(), value.collect::<Vec<&str>>().join(","));
     }
@@ -107,34 +87,10 @@ fn parse_args() -> (Properties, String, u32, Option<Regex>) {
         config.insert("multicast_scouting".into(), "false".into());
     }
 
-    let allow = if let Some(res) = args.value_of("allow") {
-        match Regex::new(res) {
-            Ok(re) => Some(re),
-            Err(e) => {
-                panic!("Unable to compile allow regular expression, please see error details below:\n {:?}\n", e)
-            }
-        }
-    } else {
-        None
-    };
+    // Disable local routing to avoid loops
+    config.insert("local_routing".into(), "false".into());
 
-    let did = if let Some(sdid) = args.value_of("domain") {
-        match sdid.parse::<u32>() {
-            Ok(adid) => adid,
-            Err(_) => panic!("ERROR: {} is not a valid domain ID ", sdid),
-        }
-    } else {
-        DDS_DOMAIN_DEFAULT
-    };
-
-    (config, scope, did, allow)
-}
-
-fn is_allowed(sre: &Option<Regex>, path: &str) -> bool {
-    match sre {
-        Some(re) => re.is_match(path),
-        _ => true,
-    }
+    (config, args.is_present("rest-plugin"), args)
 }
 
 #[async_std::main]
@@ -152,201 +108,21 @@ async fn main() {
         }
     }
 
-    const DDS_INFINITE_TIME: i64 = 0x7FFFFFFFFFFFFFFF;
     env_logger::init();
-    let (config, scope, did, allow_re) = parse_args();
-    let dp = unsafe { dds_create_participant(did, std::ptr::null(), std::ptr::null()) };
-    let z = Arc::new(open(config.into()).await.unwrap());
-    let (tx, rx): (Sender<MatchedEntity>, Receiver<MatchedEntity>) = channel();
-    run_discovery(dp, tx);
-    let mut rid_map = HashMap::<String, ResourceId>::new();
-    let mut rd_map = HashMap::<String, dds_entity_t>::new();
-    let mut wr_map = HashMap::<String, dds_entity_t>::new();
-    let _zsub_map = HashMap::<String, CallbackSubscriber>::new();
-    while let Ok(me) = rx.recv() {
-        match me {
-            MatchedEntity::DiscoveredPublication {
-                topic_name,
-                type_name,
-                keyless,
-                partition,
-                qos,
-            } => {
-                debug!(
-                    "DiscoveredPublication({}, {}, {:?}",
-                    topic_name, type_name, partition
-                );
-                let key = match partition {
-                    Some(p) => format!("{}/{}/{}", scope, p, topic_name),
-                    None => format!("{}/{}", scope, topic_name),
-                };
-                if !is_allowed(&allow_re, &key) {
-                    info!(
-                        "Ignoring Publication for key {} as it is not allowed (see --allow option)",
-                        &key
-                    );
-                    break;
-                }
-                debug!("Declaring resource {}", key);
-                match rd_map.get(&key) {
-                    None => {
-                        let rkey = ResKey::RName(key.clone());
-                        let nrid = z.declare_resource(&rkey).await.unwrap();
-                        let rid = ResKey::RId(nrid);
-                        let _ = z.declare_publisher(&rid).await;
-                        rid_map.insert(key.clone(), nrid);
-                        info!(
-                            "New route: DDS '{}' => zenoh '{}' (rid={}) with type '{}'",
-                            topic_name, key, rid, type_name
-                        );
-                        let dr: dds_entity_t = create_forwarding_dds_reader(
-                            dp,
-                            topic_name,
-                            type_name,
-                            keyless,
-                            qos,
-                            rid,
-                            z.clone(),
-                        );
-                        rd_map.insert(key, dr);
-                    }
-                    _ => {
-                        debug!(
-                            "Already forwarding matching subscription {} -- ignoring",
-                            topic_name
-                        );
-                    }
-                }
-            }
-            MatchedEntity::UndiscoveredPublication {
-                topic_name,
-                type_name,
-                partition,
-            } => {
-                debug!(
-                    "UndiscoveredPublication({}, {}, {:?}",
-                    topic_name, type_name, partition
-                );
-            }
-            MatchedEntity::DiscoveredSubscription {
-                topic_name,
-                type_name,
-                keyless,
-                partition,
-                qos,
-            } => {
-                debug!(
-                    "DiscoveredSubscription({}, {}, {:?}",
-                    topic_name, type_name, partition
-                );
-                let key = match &partition {
-                    Some(p) => format!("{}/{}/{}", scope, p, topic_name),
-                    None => format!("{}/{}", scope, topic_name),
-                };
+    let (config, rest_plugin, args) = parse_args();
 
-                if !is_allowed(&allow_re, &key) {
-                    info!("Ignoring subscription for key {} as it is not allowed (see --allow option)", &key);
-                    break;
-                }
-                if let Some(wr) = match wr_map.get(&key) {
-                    Some(_) => {
-                        debug!(
-                            "The Subscription({}, {}, {:?} is aready handled, IGNORING",
-                            topic_name, type_name, partition
-                        );
-                        None
-                    }
-                    None => {
-                        info!(
-                            "New route: zenoh '{}' => DDS '{}' with type '{}'",
-                            key, topic_name, type_name
-                        );
-                        // Workaround for the Publisher to correctly match with a FastRTPS Subscriber declaring a Reliability max_blocking_time < infinite
-                        let mut kind: dds_reliability_kind_t =
-                            dds_reliability_kind_DDS_RELIABILITY_RELIABLE;
-                        let mut max_blocking_time: dds_duration_t = 0;
-                        unsafe {
-                            if dds_qget_reliability(qos.0, &mut kind, &mut max_blocking_time)
-                                && max_blocking_time < DDS_INFINITE_TIME
-                            {
-                                // Add 1 nanosecond to max_blocking_time for the Publisher
-                                max_blocking_time += 1;
-                                dds_qset_reliability(qos.0, kind, max_blocking_time);
-                            }
-                        }
+    // create a zenoh Runtime (to share with plugins)
+    let runtime = zenoh::net::runtime::Runtime::new(0, config.into(), None)
+        .await
+        .unwrap();
 
-                        let wr = create_forwarding_dds_writer(
-                            dp,
-                            topic_name.clone(),
-                            type_name.clone(),
-                            keyless,
-                            qos,
-                        );
-                        wr_map.insert(key.clone(), wr);
-                        Some(wr)
-                    }
-                } {
-                    debug!(
-                        "The Subscription({}, {}, {:?} is new setting up zenoh and DDS endpoings",
-                        topic_name, type_name, partition
-                    );
-                    let sub_info = SubInfo {
-                        reliability: Reliability::Reliable,
-                        mode: SubMode::Push,
-                        period: None,
-                    };
-
-                    let zn = z.clone();
-                    task::spawn(async move {
-                        let rkey = ResKey::RName(key);
-                        let mut sub = zn.declare_subscriber(&rkey, &sub_info).await.unwrap();
-                        let stream = sub.stream();
-                        while let Some(d) = stream.next().await {
-                            log::trace!("Route data to DDS '{}'", topic_name);
-                            let ton = topic_name.clone();
-                            let tyn = type_name.clone();
-                            unsafe {
-                                let bs = d.payload.to_vec();
-                                // As per the Vec documentation (see https://doc.rust-lang.org/std/vec/struct.Vec.html#method.into_raw_parts)
-                                // the only way to correctly releasing it is to create a vec using from_raw_parts
-                                // and then have its destructor do the cleanup.
-                                // Thus, while tempting to just pass the raw pointer to cyclone and then free it from C,
-                                // that is not necessarily safe or guaranteed to be leak free.
-                                let (ptr, len, capacity) = bs.into_raw_parts();
-                                let cton = CString::new(ton).unwrap().into_raw();
-                                let ctyn = CString::new(tyn).unwrap().into_raw();
-                                let st = cdds_create_blob_sertopic(
-                                    dp,
-                                    cton as *mut std::os::raw::c_char,
-                                    ctyn as *mut std::os::raw::c_char,
-                                    keyless,
-                                );
-                                drop(CString::from_raw(cton));
-                                drop(CString::from_raw(ctyn));
-                                let fwdp = cdds_ddsi_payload_create(
-                                    st,
-                                    ddsi_serdata_kind_SDK_DATA,
-                                    ptr,
-                                    len as u64,
-                                );
-                                dds_writecdr(wr, fwdp as *mut ddsi_serdata);
-                                drop(Vec::from_raw_parts(ptr, len, capacity));
-                                cdds_sertopic_unref(st);
-                            };
-                        }
-                    });
-                }
-            }
-            MatchedEntity::UndiscoveredSubscription {
-                topic_name,
-                type_name,
-                partition,
-            } => {
-                debug!(
-                    "UndiscoveredSubscription({}, {}, {:?}",
-                    topic_name, type_name, partition
-                );
-            }
-        }
+    // start REST plugin
+    if rest_plugin {
+        zplugin_rest::run(runtime.clone(), args.clone()).await;
     }
+
+    // start DDS plugin
+    zplugin_dds::run(runtime.clone(), args.clone()).await;
+
+    future::pending::<()>().await;
 }

--- a/src/bin/zenoh-bridge-dds.rs
+++ b/src/bin/zenoh-bridge-dds.rs
@@ -39,16 +39,16 @@ fn customize_dds_args<'a, 'b>(mut args: Vec<Arg<'a, 'b>>) -> Vec<Arg<'a, 'b>> {
 fn parse_args() -> (Properties, bool, ArgMatches<'static>) {
     let app = App::new("zenoh bridge for DDS")
         .arg(Arg::from_usage(
-            "-e, --peer=[LOCATOR]...  'Peer locator used to initiate the zenoh session.'\n",
+            "-e, --peer=[LOCATOR]...  'Peer locator used to initiate the zenoh session.'",
         ))
         .arg(Arg::from_usage(
-            "-l, --listener=[LOCATOR]...   'Locators to listen on.'\n",
+            "-l, --listener=[LOCATOR]...   'Locators to listen on.'",
         ))
         .arg(Arg::from_usage(
-            "-c, --config=[FILE]      'A configuration file.'\n",
+            "-c, --config=[FILE]      'A configuration file.'",
         ))
         .arg(
-            Arg::from_usage("-m, --mode=[MODE]  'The zenoh session mode.'\n")
+            Arg::from_usage("-m, --mode=[MODE]  'The zenoh session mode.'")
                 .possible_values(&["peer", "client"])
                 .default_value("peer"),
         )

--- a/src/dds_mgt.rs
+++ b/src/dds_mgt.rs
@@ -25,6 +25,14 @@ use zenoh::net::{RBuf, ResKey, Session};
 
 const MAX_SAMPLES: usize = 32;
 
+#[derive(PartialEq, Debug, Serialize)]
+pub(crate) enum RouteStatus {
+    Routed,
+    RouterOnSomePartitions,
+    NotAllowed,
+    _QoSConflict,
+}
+
 #[derive(Debug, Serialize)]
 pub(crate) struct DdsEntity {
     pub(crate) key: String,
@@ -34,6 +42,7 @@ pub(crate) struct DdsEntity {
     pub(crate) partitions: Vec<String>,
     pub(crate) keyless: bool,
     pub(crate) qos: QosHolder,
+    pub(crate) route_status: Option<RouteStatus>,
 }
 
 #[derive(Debug)]
@@ -128,6 +137,7 @@ unsafe extern "C" fn on_data(dr: dds_entity_t, arg: *mut std::os::raw::c_void) {
                     keyless,
                     partitions,
                     qos: QosHolder(qos),
+                    route_status: None,
                 };
 
                 if pub_discovery {

--- a/src/dds_mgt.rs
+++ b/src/dds_mgt.rs
@@ -1,0 +1,292 @@
+//
+// Copyright (c) 2017, 2020 ADLINK Technology Inc.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ADLINK zenoh team, <zenoh@adlink-labs.tech>
+//
+use async_std::channel::Sender;
+use async_std::task;
+use cyclors::*;
+use log::debug;
+use std::ffi::{CStr, CString};
+use std::mem::MaybeUninit;
+use std::os::raw;
+use std::sync::Arc;
+use zenoh::net::{RBuf, ResKey, Session};
+
+const MAX_SAMPLES: usize = 32;
+
+#[derive(Debug)]
+pub struct QosHolder(pub *mut dds_qos_t);
+unsafe impl Send for QosHolder {}
+// unsafe impl Sync for QosHolder {}
+
+#[derive(Debug)]
+pub enum MatchedEntity {
+    DiscoveredPublication {
+        topic_name: String,
+        type_name: String,
+        keyless: bool,
+        partition: Option<String>,
+        qos: QosHolder,
+    },
+    UndiscoveredPublication {
+        topic_name: String,
+        type_name: String,
+        partition: Option<String>,
+    },
+    DiscoveredSubscription {
+        topic_name: String,
+        type_name: String,
+        keyless: bool,
+        partition: Option<String>,
+        qos: QosHolder,
+    },
+    UndiscoveredSubscription {
+        topic_name: String,
+        type_name: String,
+        partition: Option<String>,
+    },
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub fn print_qos_partitions(qos: *const dds_qos_t) {
+    let mut n: u32 = 0;
+    let mut ps: *mut *mut ::std::os::raw::c_char = std::ptr::null_mut();
+    unsafe {
+        let _ = dds_qget_partition(
+            qos,
+            &mut n as *mut u32,
+            &mut ps as *mut *mut *mut ::std::os::raw::c_char,
+        );
+        if n > 0 {
+            for k in 0..n {
+                let p = CStr::from_ptr(*(ps.offset(k as isize))).to_str().unwrap();
+                debug!("Partition[{}]: {:?}", k, p);
+            }
+        }
+    }
+}
+
+unsafe extern "C" fn on_data(dr: dds_entity_t, arg: *mut std::os::raw::c_void) {
+    let btx = Box::from_raw(arg as *mut (bool, Sender<MatchedEntity>));
+    let dp = dds_get_participant(dr);
+    let mut dpih: dds_instance_handle_t = 0;
+    let _ = dds_get_instance_handle(dp, &mut dpih);
+    debug!("Local Domain Participant IH = {:?}", dpih);
+
+    #[allow(clippy::uninit_assumed_init)]
+    let mut si: [dds_sample_info_t; MAX_SAMPLES] = { MaybeUninit::uninit().assume_init() };
+    let mut samples: [*mut ::std::os::raw::c_void; MAX_SAMPLES] =
+        [std::ptr::null_mut(); MAX_SAMPLES as usize];
+    samples[0] = std::ptr::null_mut();
+
+    let n = dds_take(
+        dr,
+        samples.as_mut_ptr() as *mut *mut raw::c_void,
+        si.as_mut_ptr() as *mut dds_sample_info_t,
+        MAX_SAMPLES as u64,
+        MAX_SAMPLES as u32,
+    );
+    for i in 0..n {
+        if si[i as usize].valid_data {
+            let sample = samples[i as usize] as *mut dds_builtintopic_endpoint_t;
+            debug!(
+                "Discovery data from Participant with IH = {:?}",
+                (*sample).participant_instance_handle
+            );
+            let keyless = (*sample).key.v[15] == 3 || (*sample).key.v[15] == 4;
+            debug!("Discovered endpoint is keyless: {}", keyless);
+            let topic_name = CStr::from_ptr((*sample).topic_name).to_str().unwrap();
+            if topic_name.contains("DCPS") || (*sample).participant_instance_handle == dpih {
+                debug!("Ignoring discovery from local participant: {}", topic_name);
+                // print_qos_partitions((*sample).qos);
+                continue;
+            }
+            let type_name = CStr::from_ptr((*sample).type_name).to_str().unwrap();
+            let mut n = 0u32;
+            let mut ps: *mut *mut ::std::os::raw::c_char = std::ptr::null_mut();
+            let qos = dds_create_qos();
+            dds_copy_qos(qos, (*sample).qos);
+            dds_qset_ignorelocal(qos, dds_ignorelocal_kind_DDS_IGNORELOCAL_PARTICIPANT);
+            dds_qset_history(qos, dds_history_kind_DDS_HISTORY_KEEP_ALL, 0);
+            let _ = dds_qget_partition(
+                (*sample).qos,
+                &mut n as *mut u32,
+                &mut ps as *mut *mut *mut ::std::os::raw::c_char,
+            );
+            if n > 0 {
+                for k in 0..n {
+                    let p = CStr::from_ptr(*(ps.offset(k as isize))).to_str().unwrap();
+                    if si[i as usize].instance_state == dds_instance_state_DDS_IST_ALIVE {
+                        if btx.0 {
+                            (btx.1)
+                                .try_send(MatchedEntity::DiscoveredPublication {
+                                    topic_name: String::from(topic_name),
+                                    type_name: String::from(type_name),
+                                    keyless,
+                                    partition: Some(String::from(p)),
+                                    qos: QosHolder(qos),
+                                })
+                                .unwrap();
+                        } else {
+                            (btx.1)
+                                .try_send(MatchedEntity::DiscoveredSubscription {
+                                    topic_name: String::from(topic_name),
+                                    type_name: String::from(type_name),
+                                    keyless,
+                                    partition: Some(String::from(p)),
+                                    qos: QosHolder(qos),
+                                })
+                                .unwrap();
+                        }
+                    } else if btx.0 {
+                        (btx.1)
+                            .try_send(MatchedEntity::UndiscoveredPublication {
+                                topic_name: String::from(topic_name),
+                                type_name: String::from(type_name),
+                                partition: Some(String::from(p)),
+                            })
+                            .unwrap();
+                    } else {
+                        (btx.1)
+                            .try_send(MatchedEntity::UndiscoveredSubscription {
+                                topic_name: String::from(topic_name),
+                                type_name: String::from(type_name),
+                                partition: Some(String::from(p)),
+                            })
+                            .unwrap();
+                    }
+                }
+            } else if si[i as usize].instance_state == dds_instance_state_DDS_IST_ALIVE {
+                if btx.0 {
+                    (btx.1)
+                        .try_send(MatchedEntity::DiscoveredPublication {
+                            topic_name: String::from(topic_name),
+                            type_name: String::from(type_name),
+                            keyless,
+                            partition: None,
+                            qos: QosHolder(qos),
+                        })
+                        .unwrap();
+                } else {
+                    (btx.1)
+                        .try_send(MatchedEntity::DiscoveredSubscription {
+                            topic_name: String::from(topic_name),
+                            type_name: String::from(type_name),
+                            keyless,
+                            partition: None,
+                            qos: QosHolder(qos),
+                        })
+                        .unwrap();
+                }
+            } else if btx.0 {
+                (btx.1)
+                    .try_send(MatchedEntity::UndiscoveredPublication {
+                        topic_name: String::from(topic_name),
+                        type_name: String::from(type_name),
+                        partition: None,
+                    })
+                    .unwrap();
+            } else {
+                (btx.1)
+                    .try_send(MatchedEntity::UndiscoveredSubscription {
+                        topic_name: String::from(topic_name),
+                        type_name: String::from(type_name),
+                        partition: None,
+                    })
+                    .unwrap();
+            }
+        }
+    }
+    dds_return_loan(
+        dr,
+        samples.as_mut_ptr() as *mut *mut raw::c_void,
+        MAX_SAMPLES as i32,
+    );
+    Box::into_raw(btx);
+}
+pub fn run_discovery(dp: dds_entity_t, tx: Sender<MatchedEntity>) {
+    unsafe {
+        let ptx = Box::new((true, tx.clone()));
+        let stx = Box::new((false, tx));
+        let sub_listener = dds_create_listener(Box::into_raw(ptx) as *mut std::os::raw::c_void);
+        dds_lset_data_available(sub_listener, Some(on_data));
+
+        let _pr = dds_create_reader(
+            dp,
+            DDS_BUILTIN_TOPIC_DCPSPUBLICATION,
+            std::ptr::null(),
+            sub_listener,
+        );
+
+        let sub_listener = dds_create_listener(Box::into_raw(stx) as *mut std::os::raw::c_void);
+        dds_lset_data_available(sub_listener, Some(on_data));
+        let _sr = dds_create_reader(
+            dp,
+            DDS_BUILTIN_TOPIC_DCPSSUBSCRIPTION,
+            std::ptr::null(),
+            sub_listener,
+        );
+    }
+}
+
+unsafe extern "C" fn data_forwarder_listener(dr: dds_entity_t, arg: *mut std::os::raw::c_void) {
+    let pa = arg as *mut (ResKey, Arc<Session>);
+    let mut zp: *mut cdds_ddsi_payload = std::ptr::null_mut();
+    #[allow(clippy::uninit_assumed_init)]
+    let mut si: [dds_sample_info_t; 1] = { MaybeUninit::uninit().assume_init() };
+    while cdds_take_blob(dr, &mut zp, si.as_mut_ptr()) > 0 {
+        if si[0].valid_data {
+            log::trace!("Route data to zenoh resource with rid={}", &(*pa).0);
+            let bs = Vec::from_raw_parts((*zp).payload, (*zp).size as usize, (*zp).size as usize);
+            let rbuf = RBuf::from(bs);
+            let _ = task::block_on(async { (*pa).1.write(&(*pa).0, rbuf).await });
+            (*zp).payload = std::ptr::null_mut();
+        }
+        cdds_serdata_unref(zp as *mut ddsi_serdata);
+    }
+}
+pub fn create_forwarding_dds_reader(
+    dp: dds_entity_t,
+    topic_name: String,
+    type_name: String,
+    keyless: bool,
+    qos: QosHolder,
+    z_key: ResKey,
+    z: Arc<Session>,
+) -> dds_entity_t {
+    let cton = CString::new(topic_name).unwrap().into_raw();
+    let ctyn = CString::new(type_name).unwrap().into_raw();
+
+    unsafe {
+        let t = cdds_create_blob_topic(dp, cton, ctyn, keyless);
+        let arg = Box::new((z_key, z));
+        let sub_listener = dds_create_listener(Box::into_raw(arg) as *mut std::os::raw::c_void);
+        dds_lset_data_available(sub_listener, Some(data_forwarder_listener));
+        dds_create_reader(dp, t, qos.0, sub_listener)
+    }
+}
+
+pub fn create_forwarding_dds_writer(
+    dp: dds_entity_t,
+    topic_name: String,
+    type_name: String,
+    keyless: bool,
+    qos: QosHolder,
+) -> dds_entity_t {
+    let cton = CString::new(topic_name).unwrap().into_raw();
+    let ctyn = CString::new(type_name).unwrap().into_raw();
+
+    unsafe {
+        let t = cdds_create_blob_topic(dp, cton, ctyn, keyless);
+        dds_create_writer(dp, t, qos.0, std::ptr::null_mut())
+    }
+}

--- a/src/dds_mgt.rs
+++ b/src/dds_mgt.rs
@@ -15,6 +15,8 @@ use async_std::channel::Sender;
 use async_std::task;
 use cyclors::*;
 use log::debug;
+use serde::ser::SerializeStruct;
+use serde::{Serialize, Serializer};
 use std::ffi::{CStr, CString};
 use std::mem::MaybeUninit;
 use std::os::raw;
@@ -26,34 +28,44 @@ const MAX_SAMPLES: usize = 32;
 #[derive(Debug)]
 pub struct QosHolder(pub *mut dds_qos_t);
 unsafe impl Send for QosHolder {}
-// unsafe impl Sync for QosHolder {}
+unsafe impl Sync for QosHolder {}
+
+impl Serialize for QosHolder {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut s = serializer.serialize_struct("QoS", 2)?;
+
+        let mut kind: dds_reliability_kind_t = dds_reliability_kind_DDS_RELIABILITY_RELIABLE;
+        let mut max_blocking_time: dds_duration_t = 0;
+        unsafe {
+            if dds_qget_reliability(self.0, &mut kind, &mut max_blocking_time) {
+                s.serialize_field("reliability_kind", &kind)?;
+                s.serialize_field("reliability_max_blocking_time", &max_blocking_time)?;
+            }
+        }
+        s.end()
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct DdsEntity {
+    pub(crate) key: String,
+    pub(crate) participant_key: String,
+    pub(crate) topic_name: String,
+    pub(crate) type_name: String,
+    pub(crate) keyless: bool,
+    pub(crate) partitions: Vec<String>,
+    pub(crate) qos: QosHolder,
+}
 
 #[derive(Debug)]
-pub enum MatchedEntity {
-    DiscoveredPublication {
-        topic_name: String,
-        type_name: String,
-        keyless: bool,
-        partition: Option<String>,
-        qos: QosHolder,
-    },
-    UndiscoveredPublication {
-        topic_name: String,
-        type_name: String,
-        partition: Option<String>,
-    },
-    DiscoveredSubscription {
-        topic_name: String,
-        type_name: String,
-        keyless: bool,
-        partition: Option<String>,
-        qos: QosHolder,
-    },
-    UndiscoveredSubscription {
-        topic_name: String,
-        type_name: String,
-        partition: Option<String>,
-    },
+pub(crate) enum DiscoveryEvent {
+    DiscoveredPublication { entity: DdsEntity },
+    UndiscoveredPublication { key: String },
+    DiscoveredSubscription { entity: DdsEntity },
+    UndiscoveredSubscription { key: String },
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -76,11 +88,11 @@ pub fn print_qos_partitions(qos: *const dds_qos_t) {
 }
 
 unsafe extern "C" fn on_data(dr: dds_entity_t, arg: *mut std::os::raw::c_void) {
-    let btx = Box::from_raw(arg as *mut (bool, Sender<MatchedEntity>));
+    let btx = Box::from_raw(arg as *mut (bool, Sender<DiscoveryEvent>));
+    let pub_discovery: bool = btx.0;
     let dp = dds_get_participant(dr);
     let mut dpih: dds_instance_handle_t = 0;
     let _ = dds_get_instance_handle(dp, &mut dpih);
-    debug!("Local Domain Participant IH = {:?}", dpih);
 
     #[allow(clippy::uninit_assumed_init)]
     let mut si: [dds_sample_info_t; MAX_SAMPLES] = { MaybeUninit::uninit().assume_init() };
@@ -98,110 +110,85 @@ unsafe extern "C" fn on_data(dr: dds_entity_t, arg: *mut std::os::raw::c_void) {
     for i in 0..n {
         if si[i as usize].valid_data {
             let sample = samples[i as usize] as *mut dds_builtintopic_endpoint_t;
-            debug!(
-                "Discovery data from Participant with IH = {:?}",
-                (*sample).participant_instance_handle
-            );
+            let is_alive = si[i as usize].instance_state == dds_instance_state_DDS_IST_ALIVE;
+            let key = hex::encode((*sample).key.v);
+            let participant_key = hex::encode((*sample).participant_key.v);
             let keyless = (*sample).key.v[15] == 3 || (*sample).key.v[15] == 4;
-            debug!("Discovered endpoint is keyless: {}", keyless);
             let topic_name = CStr::from_ptr((*sample).topic_name).to_str().unwrap();
+            let type_name = CStr::from_ptr((*sample).type_name).to_str().unwrap();
+
+            debug!(
+                "{} DDS {} {} from Participant {} on {} with type {} (keyless: {})",
+                if is_alive {
+                    "Discovered"
+                } else {
+                    "Undiscovered"
+                },
+                if pub_discovery {
+                    "publication"
+                } else {
+                    "subscription"
+                },
+                key,
+                participant_key,
+                topic_name,
+                type_name,
+                keyless
+            );
+
             if topic_name.contains("DCPS") || (*sample).participant_instance_handle == dpih {
-                debug!("Ignoring discovery from local participant: {}", topic_name);
-                // print_qos_partitions((*sample).qos);
+                debug!(
+                    "Ignoring discovery of {} ({}) from local participant",
+                    key, topic_name
+                );
                 continue;
             }
-            let type_name = CStr::from_ptr((*sample).type_name).to_str().unwrap();
-            let mut n = 0u32;
-            let mut ps: *mut *mut ::std::os::raw::c_char = std::ptr::null_mut();
-            let qos = dds_create_qos();
-            dds_copy_qos(qos, (*sample).qos);
-            dds_qset_ignorelocal(qos, dds_ignorelocal_kind_DDS_IGNORELOCAL_PARTICIPANT);
-            dds_qset_history(qos, dds_history_kind_DDS_HISTORY_KEEP_ALL, 0);
-            let _ = dds_qget_partition(
-                (*sample).qos,
-                &mut n as *mut u32,
-                &mut ps as *mut *mut *mut ::std::os::raw::c_char,
-            );
-            if n > 0 {
+
+            // send a DiscoveryEvent
+            if si[i as usize].instance_state == dds_instance_state_DDS_IST_ALIVE {
+                let qos = dds_create_qos();
+                dds_copy_qos(qos, (*sample).qos);
+
+                // get partitions list if any
+                let mut n = 0u32;
+                let mut ps: *mut *mut ::std::os::raw::c_char = std::ptr::null_mut();
+                let _ = dds_qget_partition(
+                    (*sample).qos,
+                    &mut n as *mut u32,
+                    &mut ps as *mut *mut *mut ::std::os::raw::c_char,
+                );
+                let mut partitions: Vec<String> = Vec::with_capacity(n as usize);
                 for k in 0..n {
                     let p = CStr::from_ptr(*(ps.offset(k as isize))).to_str().unwrap();
-                    if si[i as usize].instance_state == dds_instance_state_DDS_IST_ALIVE {
-                        if btx.0 {
-                            (btx.1)
-                                .try_send(MatchedEntity::DiscoveredPublication {
-                                    topic_name: String::from(topic_name),
-                                    type_name: String::from(type_name),
-                                    keyless,
-                                    partition: Some(String::from(p)),
-                                    qos: QosHolder(qos),
-                                })
-                                .unwrap();
-                        } else {
-                            (btx.1)
-                                .try_send(MatchedEntity::DiscoveredSubscription {
-                                    topic_name: String::from(topic_name),
-                                    type_name: String::from(type_name),
-                                    keyless,
-                                    partition: Some(String::from(p)),
-                                    qos: QosHolder(qos),
-                                })
-                                .unwrap();
-                        }
-                    } else if btx.0 {
-                        (btx.1)
-                            .try_send(MatchedEntity::UndiscoveredPublication {
-                                topic_name: String::from(topic_name),
-                                type_name: String::from(type_name),
-                                partition: Some(String::from(p)),
-                            })
-                            .unwrap();
-                    } else {
-                        (btx.1)
-                            .try_send(MatchedEntity::UndiscoveredSubscription {
-                                topic_name: String::from(topic_name),
-                                type_name: String::from(type_name),
-                                partition: Some(String::from(p)),
-                            })
-                            .unwrap();
-                    }
+                    partitions.push(String::from(p));
                 }
-            } else if si[i as usize].instance_state == dds_instance_state_DDS_IST_ALIVE {
-                if btx.0 {
+
+                let entity = DdsEntity {
+                    key: key.clone(),
+                    participant_key: participant_key.clone(),
+                    topic_name: String::from(topic_name),
+                    type_name: String::from(type_name),
+                    keyless,
+                    partitions,
+                    qos: QosHolder(qos),
+                };
+
+                if pub_discovery {
                     (btx.1)
-                        .try_send(MatchedEntity::DiscoveredPublication {
-                            topic_name: String::from(topic_name),
-                            type_name: String::from(type_name),
-                            keyless,
-                            partition: None,
-                            qos: QosHolder(qos),
-                        })
+                        .try_send(DiscoveryEvent::DiscoveredPublication { entity })
                         .unwrap();
                 } else {
                     (btx.1)
-                        .try_send(MatchedEntity::DiscoveredSubscription {
-                            topic_name: String::from(topic_name),
-                            type_name: String::from(type_name),
-                            keyless,
-                            partition: None,
-                            qos: QosHolder(qos),
-                        })
+                        .try_send(DiscoveryEvent::DiscoveredSubscription { entity })
                         .unwrap();
                 }
-            } else if btx.0 {
+            } else if pub_discovery {
                 (btx.1)
-                    .try_send(MatchedEntity::UndiscoveredPublication {
-                        topic_name: String::from(topic_name),
-                        type_name: String::from(type_name),
-                        partition: None,
-                    })
+                    .try_send(DiscoveryEvent::UndiscoveredPublication { key })
                     .unwrap();
             } else {
                 (btx.1)
-                    .try_send(MatchedEntity::UndiscoveredSubscription {
-                        topic_name: String::from(topic_name),
-                        type_name: String::from(type_name),
-                        partition: None,
-                    })
+                    .try_send(DiscoveryEvent::UndiscoveredSubscription { key })
                     .unwrap();
             }
         }
@@ -213,7 +200,8 @@ unsafe extern "C" fn on_data(dr: dds_entity_t, arg: *mut std::os::raw::c_void) {
     );
     Box::into_raw(btx);
 }
-pub fn run_discovery(dp: dds_entity_t, tx: Sender<MatchedEntity>) {
+
+pub(crate) fn run_discovery(dp: dds_entity_t, tx: Sender<DiscoveryEvent>) {
     unsafe {
         let ptx = Box::new((true, tx.clone()));
         let stx = Box::new((false, tx));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,10 @@ impl DdsPlugin {
 
     fn insert_dds_writer(&mut self, e: DdsEntity) {
         // insert reference in admin_space
-        let path = format!("participant/{}/writer/{}", e.participant_key, e.key);
+        let path = format!(
+            "participant/{}/writer/{}/{}",
+            e.participant_key, e.key, e.topic_name
+        );
         self.admin_space
             .insert(path, AdminRef::DdsWriterEntity(e.key.clone()));
 
@@ -218,7 +221,10 @@ impl DdsPlugin {
         // remove from dds_writer map
         if let Some(e) = self.dds_writer.remove(key) {
             // remove from admin space
-            let path = format!("participant/{}/writer/{}", e.participant_key, e.key);
+            let path = format!(
+                "participant/{}/writer/{}/{}",
+                e.participant_key, e.key, e.topic_name
+            );
             self.admin_space.remove(&path);
 
             // TODO: check is matching routes are unused and remove them

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,16 +63,7 @@ pub fn start(runtime: Runtime, args: &'static ArgMatches<'_>) {
     async_std::task::spawn(run(runtime, args.clone()));
 }
 
-fn is_allowed(sre: &Option<Regex>, path: &str) -> bool {
-    match sre {
-        Some(re) => re.is_match(path),
-        _ => true,
-    }
-}
-
 pub async fn run(runtime: Runtime, args: ArgMatches<'_>) {
-    const DDS_INFINITE_TIME: i64 = 0x7FFFFFFFFFFFFFFF;
-
     // Try to initiate login.
     // Required in case of dynamic lib, otherwise no logs.
     // But cannot be done twice in case of static link.
@@ -84,7 +75,7 @@ pub async fn run(runtime: Runtime, args: ArgMatches<'_>) {
         .or_else(|| Some(String::from("")))
         .unwrap();
 
-    let did = if let Some(sdid) = args.value_of("dds-domain") {
+    let domain_id = if let Some(sdid) = args.value_of("dds-domain") {
         match sdid.parse::<u32>() {
             Ok(adid) => adid,
             Err(_) => panic!("ERROR: {} is not a valid domain ID ", sdid),
@@ -119,203 +110,263 @@ pub async fn run(runtime: Runtime, args: ArgMatches<'_>) {
     let z = Arc::new(Session::init(runtime, true, join_subscriptions, join_publications).await);
 
     // create DDS Participant
-    let dp = unsafe { dds_create_participant(did, std::ptr::null(), std::ptr::null()) };
-    let (tx, rx): (Sender<MatchedEntity>, Receiver<MatchedEntity>) = unbounded();
-    run_discovery(dp, tx);
-    let mut rid_map = HashMap::<String, ResourceId>::new();
-    let mut rd_map = HashMap::<String, dds_entity_t>::new();
-    let mut wr_map = HashMap::<String, dds_entity_t>::new();
-    let _zsub_map = HashMap::<String, CallbackSubscriber>::new();
-    loop {
-        select!(
-            me = rx.recv().fuse() => {
-                match me.unwrap() {
-                    MatchedEntity::DiscoveredPublication {
-                        topic_name,
-                        type_name,
-                        keyless,
-                        partition,
-                        qos,
-                    } => {
-                        debug!(
-                            "DiscoveredPublication({}, {}, {:?}",
-                            topic_name, type_name, partition
-                        );
-                        let key = match partition {
-                            Some(p) => format!("{}/{}/{}", scope, p, topic_name),
-                            None => format!("{}/{}", scope, topic_name),
-                        };
-                        if !is_allowed(&allow_re, &key) {
-                            info!(
-                                "Ignoring Publication for key {} as it is not allowed (see --allow option)",
-                                &key
-                            );
-                            break;
-                        }
-                        debug!("Declaring resource {}", key);
-                        match rd_map.get(&key) {
-                            None => {
-                                let rkey = ResKey::RName(key.clone());
-                                let nrid = z.declare_resource(&rkey).await.unwrap();
-                                let rid = ResKey::RId(nrid);
-                                let _ = z.declare_publisher(&rid).await;
-                                rid_map.insert(key.clone(), nrid);
-                                info!(
-                                    "New route: DDS '{}' => zenoh '{}' (rid={}) with type '{}'",
-                                    topic_name, key, rid, type_name
-                                );
-                                let dr: dds_entity_t = create_forwarding_dds_reader(
-                                    dp,
-                                    topic_name,
-                                    type_name,
-                                    keyless,
-                                    qos,
-                                    rid,
-                                    z.clone(),
-                                );
-                                rd_map.insert(key, dr);
-                            }
-                            _ => {
-                                debug!(
-                                    "Already forwarding matching subscription {} -- ignoring",
-                                    topic_name
-                                );
-                            }
-                        }
-                    }
-                    MatchedEntity::UndiscoveredPublication {
-                        topic_name,
-                        type_name,
-                        partition,
-                    } => {
-                        debug!(
-                            "UndiscoveredPublication({}, {}, {:?}",
-                            topic_name, type_name, partition
-                        );
-                    }
-                    MatchedEntity::DiscoveredSubscription {
-                        topic_name,
-                        type_name,
-                        keyless,
-                        partition,
-                        qos,
-                    } => {
-                        debug!(
-                            "DiscoveredSubscription({}, {}, {:?}",
-                            topic_name, type_name, partition
-                        );
-                        let key = match &partition {
-                            Some(p) => format!("{}/{}/{}", scope, p, topic_name),
-                            None => format!("{}/{}", scope, topic_name),
-                        };
+    let dp = unsafe { dds_create_participant(domain_id, std::ptr::null(), std::ptr::null()) };
 
-                        if !is_allowed(&allow_re, &key) {
-                            info!("Ignoring subscription for key {} as it is not allowed (see --allow option)", &key);
-                            break;
-                        }
-                        if let Some(wr) = match wr_map.get(&key) {
-                            Some(_) => {
-                                debug!(
-                                    "The Subscription({}, {}, {:?} is aready handled, IGNORING",
-                                    topic_name, type_name, partition
-                                );
-                                None
-                            }
-                            None => {
-                                info!(
-                                    "New route: zenoh '{}' => DDS '{}' with type '{}'",
-                                    key, topic_name, type_name
-                                );
-                                // Workaround for the Publisher to correctly match with a FastRTPS Subscriber declaring a Reliability max_blocking_time < infinite
-                                let mut kind: dds_reliability_kind_t =
-                                    dds_reliability_kind_DDS_RELIABILITY_RELIABLE;
-                                let mut max_blocking_time: dds_duration_t = 0;
-                                unsafe {
-                                    if dds_qget_reliability(qos.0, &mut kind, &mut max_blocking_time)
-                                        && max_blocking_time < DDS_INFINITE_TIME
-                                    {
-                                        // Add 1 nanosecond to max_blocking_time for the Publisher
-                                        max_blocking_time += 1;
-                                        dds_qset_reliability(qos.0, kind, max_blocking_time);
-                                    }
-                                }
+    let mut dds_plugin = DdsPlugin {
+        scope,
+        domain_id,
+        allow_re,
+        z,
+        dp,
+        dds_pub: HashMap::<String, DdsEntity>::new(),
+        dds_sub: HashMap::<String, DdsEntity>::new(),
+        routes_from_dds: HashMap::<String, dds_entity_t>::new(),
+        routes_to_dds: HashMap::<String, dds_entity_t>::new(),
+    };
 
-                                let wr = create_forwarding_dds_writer(
-                                    dp,
-                                    topic_name.clone(),
-                                    type_name.clone(),
-                                    keyless,
-                                    qos,
-                                );
-                                wr_map.insert(key.clone(), wr);
-                                Some(wr)
-                            }
-                        } {
-                            debug!(
-                                "The Subscription({}, {}, {:?} is new setting up zenoh and DDS endpoings",
-                                topic_name, type_name, partition
-                            );
-                            let sub_info = SubInfo {
-                                reliability: Reliability::Reliable,
-                                mode: SubMode::Push,
-                                period: None,
-                            };
+    dds_plugin.run().await;
+}
 
-                            let zn = z.clone();
-                            task::spawn(async move {
-                                let rkey = ResKey::RName(key);
-                                let mut sub = zn.declare_subscriber(&rkey, &sub_info).await.unwrap();
-                                let stream = sub.stream();
-                                while let Some(d) = stream.next().await {
-                                    log::trace!("Route data to DDS '{}'", topic_name);
-                                    let ton = topic_name.clone();
-                                    let tyn = type_name.clone();
-                                    unsafe {
-                                        let bs = d.payload.to_vec();
-                                        // As per the Vec documentation (see https://doc.rust-lang.org/std/vec/struct.Vec.html#method.into_raw_parts)
-                                        // the only way to correctly releasing it is to create a vec using from_raw_parts
-                                        // and then have its destructor do the cleanup.
-                                        // Thus, while tempting to just pass the raw pointer to cyclone and then free it from C,
-                                        // that is not necessarily safe or guaranteed to be leak free.
-                                        let (ptr, len, capacity) = bs.into_raw_parts();
-                                        let cton = CString::new(ton).unwrap().into_raw();
-                                        let ctyn = CString::new(tyn).unwrap().into_raw();
-                                        let st = cdds_create_blob_sertopic(
-                                            dp,
-                                            cton as *mut std::os::raw::c_char,
-                                            ctyn as *mut std::os::raw::c_char,
-                                            keyless,
-                                        );
-                                        drop(CString::from_raw(cton));
-                                        drop(CString::from_raw(ctyn));
-                                        let fwdp = cdds_ddsi_payload_create(
-                                            st,
-                                            ddsi_serdata_kind_SDK_DATA,
-                                            ptr,
-                                            len as u64,
-                                        );
-                                        dds_writecdr(wr, fwdp as *mut ddsi_serdata);
-                                        drop(Vec::from_raw_parts(ptr, len, capacity));
-                                        cdds_sertopic_unref(st);
-                                    };
-                                }
-                            });
-                        }
-                    }
-                    MatchedEntity::UndiscoveredSubscription {
-                        topic_name,
-                        type_name,
-                        partition,
-                    } => {
-                        debug!(
-                            "UndiscoveredSubscription({}, {}, {:?}",
-                            topic_name, type_name, partition
-                        );
-                    }
-                }
-            }
-        )
+enum RouteStatus {
+    Created,
+    NotAllowed,
+    _QoSConflict,
+}
+
+struct DdsPlugin {
+    scope: String,
+    domain_id: u32,
+    allow_re: Option<Regex>,
+    z: Arc<Session>,
+    dp: dds_entity_t,
+    // maps of all discovered DDS entities (indexed by DDS key)
+    dds_pub: HashMap<String, DdsEntity>,
+    dds_sub: HashMap<String, DdsEntity>,
+    // maps of established routes from/to DDS (indexed by zenoh resource key)
+    routes_from_dds: HashMap<String, dds_entity_t>,
+    routes_to_dds: HashMap<String, dds_entity_t>,
+}
+
+impl DdsPlugin {
+    const DDS_INFINITE_TIME: i64 = 0x7FFFFFFFFFFFFFFF;
+
+    fn is_allowed(&self, path: &str) -> bool {
+        match &self.allow_re {
+            Some(re) => re.is_match(path),
+            _ => true,
+        }
     }
 
-    drop(rx);
+    async fn try_add_route_from_dds(
+        &mut self,
+        zkey: &str,
+        pub_to_match: &DdsEntity,
+    ) -> RouteStatus {
+        if !self.is_allowed(zkey) {
+            info!(
+                "Ignoring Publication for resource {} as it is not allowed (see --allow option)",
+                zkey
+            );
+            return RouteStatus::NotAllowed;
+        }
+
+        if self.routes_from_dds.contains_key(zkey) {
+            // TODO: check if there is no QoS conflict with existing route
+            debug!(
+                "Route from DDS to resource {} already exists -- ignoring",
+                zkey
+            );
+            return RouteStatus::Created;
+        }
+
+        // declare the zenoh resource and the publisher
+        let rkey = ResKey::RName(zkey.to_string());
+        let nrid = self.z.declare_resource(&rkey).await.unwrap();
+        let rid = ResKey::RId(nrid);
+        let _ = self.z.declare_publisher(&rid).await;
+
+        info!(
+            "New route: DDS '{}' => zenoh '{}' (rid={}) with type '{}'",
+            pub_to_match.topic_name, zkey, rid, pub_to_match.type_name
+        );
+
+        // create matching DDS Reader that forwards to zenoh
+        let qos = unsafe {
+            let qos = dds_create_qos();
+            dds_copy_qos(qos, pub_to_match.qos.0);
+            dds_qset_ignorelocal(qos, dds_ignorelocal_kind_DDS_IGNORELOCAL_PARTICIPANT);
+            dds_qset_history(qos, dds_history_kind_DDS_HISTORY_KEEP_ALL, 0);
+            qos
+        };
+        let dr: dds_entity_t = create_forwarding_dds_reader(
+            self.dp,
+            pub_to_match.topic_name.clone(),
+            pub_to_match.type_name.clone(),
+            pub_to_match.keyless,
+            QosHolder(qos),
+            rid,
+            self.z.clone(),
+        );
+
+        self.routes_from_dds.insert(zkey.to_string(), dr);
+        RouteStatus::Created
+    }
+
+    async fn try_add_route_to_dds(&mut self, zkey: &str, sub_to_match: &DdsEntity) -> RouteStatus {
+        if let Some(re) = &self.allow_re {
+            if !re.is_match(zkey) {
+                info!(
+                        "Ignoring Subscription for resource {} as it is not allowed (see --allow option)",
+                        zkey
+                    );
+                return RouteStatus::NotAllowed;
+            }
+        }
+
+        if self.routes_from_dds.contains_key(zkey) {
+            // TODO: check if there is no type or QoS conflict with existing route
+            debug!(
+                "Route from resource {} to DDS already exists -- ignoring",
+                zkey
+            );
+            return RouteStatus::Created;
+        }
+
+        info!(
+            "New route: zenoh '{}' => DDS '{}' with type '{}'",
+            zkey, sub_to_match.topic_name, sub_to_match.type_name
+        );
+
+        // create matching DDS Writer that forwards data coming from zenoh
+        let qos = unsafe {
+            let qos = dds_create_qos();
+            dds_copy_qos(qos, sub_to_match.qos.0);
+            dds_qset_ignorelocal(qos, dds_ignorelocal_kind_DDS_IGNORELOCAL_PARTICIPANT);
+            dds_qset_history(qos, dds_history_kind_DDS_HISTORY_KEEP_ALL, 0);
+
+            // Workaround for the DDS Writer to correctly match with a FastRTPS Reader declaring a Reliability max_blocking_time < infinite
+            let mut kind: dds_reliability_kind_t = dds_reliability_kind_DDS_RELIABILITY_RELIABLE;
+            let mut max_blocking_time: dds_duration_t = 0;
+            if dds_qget_reliability(qos, &mut kind, &mut max_blocking_time)
+                && max_blocking_time < Self::DDS_INFINITE_TIME
+            {
+                // Add 1 nanosecond to max_blocking_time for the Publisher
+                max_blocking_time += 1;
+                dds_qset_reliability(qos, kind, max_blocking_time);
+            }
+            qos
+        };
+
+        let wr = create_forwarding_dds_writer(
+            self.dp,
+            sub_to_match.topic_name.clone(),
+            sub_to_match.type_name.clone(),
+            sub_to_match.keyless,
+            QosHolder(qos),
+        );
+
+        // create zenoh subscriber
+        let sub_info = SubInfo {
+            reliability: Reliability::Reliable,
+            mode: SubMode::Push,
+            period: None,
+        };
+
+        let zn = self.z.clone();
+        let rkey = ResKey::RName(zkey.to_string());
+        let ton = sub_to_match.topic_name.clone();
+        let tyn = sub_to_match.type_name.clone();
+        let keyless = sub_to_match.keyless;
+        let dp = self.dp;
+        task::spawn(async move {
+            let mut sub = zn.declare_subscriber(&rkey, &sub_info).await.unwrap();
+            let stream = sub.stream();
+            while let Some(d) = stream.next().await {
+                log::trace!("Route data to DDS '{}'", &ton);
+                unsafe {
+                    let bs = d.payload.to_vec();
+                    // As per the Vec documentation (see https://doc.rust-lang.org/std/vec/struct.Vec.html#method.into_raw_parts)
+                    // the only way to correctly releasing it is to create a vec using from_raw_parts
+                    // and then have its destructor do the cleanup.
+                    // Thus, while tempting to just pass the raw pointer to cyclone and then free it from C,
+                    // that is not necessarily safe or guaranteed to be leak free.
+                    let (ptr, len, capacity) = bs.into_raw_parts();
+                    let cton = CString::new(ton.clone()).unwrap().into_raw();
+                    let ctyn = CString::new(tyn.clone()).unwrap().into_raw();
+                    let st = cdds_create_blob_sertopic(
+                        dp,
+                        cton as *mut std::os::raw::c_char,
+                        ctyn as *mut std::os::raw::c_char,
+                        keyless,
+                    );
+                    drop(CString::from_raw(cton));
+                    drop(CString::from_raw(ctyn));
+                    let fwdp =
+                        cdds_ddsi_payload_create(st, ddsi_serdata_kind_SDK_DATA, ptr, len as u64);
+                    dds_writecdr(wr, fwdp as *mut ddsi_serdata);
+                    drop(Vec::from_raw_parts(ptr, len, capacity));
+                    cdds_sertopic_unref(st);
+                };
+            }
+        });
+
+        self.routes_to_dds.insert(zkey.to_string(), wr);
+        RouteStatus::Created
+    }
+
+    async fn run(&mut self) {
+        let (tx, rx): (Sender<DiscoveryEvent>, Receiver<DiscoveryEvent>) = unbounded();
+        run_discovery(self.dp, tx);
+
+        loop {
+            select!(
+                me = rx.recv().fuse() => {
+                    match me.unwrap() {
+                        DiscoveryEvent::DiscoveredPublication {
+                            entity
+                        } => {
+                            if entity.partitions.is_empty() {
+                                let zkey = format!("{}/{}", self.scope, entity.topic_name);
+                                let _route_status = self.try_add_route_from_dds(&zkey, &entity).await;
+                            } else {
+                                for p in &entity.partitions {
+                                    let zkey = format!("{}/{}/{}", self.scope, p, entity.topic_name);
+                                    let _route_status = self.try_add_route_from_dds(&zkey, &entity).await;
+                                }
+                            }
+                            self.dds_pub.insert(entity.key.clone(), entity);
+                        }
+                        DiscoveryEvent::UndiscoveredPublication {
+                            key,
+                        } => {
+                            if let Some(_entity) = self.dds_pub.remove(&key) {
+                                // TODO: check is matching routes are unused and remove them
+                            }
+                        }
+                        DiscoveryEvent::DiscoveredSubscription {
+                            entity
+                        } => {
+                            if entity.partitions.is_empty() {
+                                let zkey = format!("{}/{}", self.scope, entity.topic_name);
+                                let _route_status = self.try_add_route_to_dds(&zkey, &entity).await;
+                            } else {
+                                for p in &entity.partitions {
+                                    let zkey = format!("{}/{}/{}", self.scope, p, entity.topic_name);
+                                    let _route_status = self.try_add_route_to_dds(&zkey, &entity).await;
+                                }
+                            }
+                            self.dds_sub.insert(entity.key.clone(), entity);
+                        }
+                        DiscoveryEvent::UndiscoveredSubscription {
+                            key,
+                        } => {
+                            if let Some(_entity) = self.dds_sub.remove(&key) {
+                                // TODO: check is matching routes are unused and remove them
+                            }
+                        }
+                    }
+                }
+            )
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,10 +37,10 @@ use qos::*;
 mod dds_mgt;
 use dds_mgt::*;
 
-#[no_mangle]
-pub fn get_expected_args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
-    get_expected_args2()
-}
+// #[no_mangle]
+// pub fn get_expected_args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
+//     get_expected_args2()
+// }
 
 // NOTE: temporary hack for static link of DDS plugin in zenoh-bridge-dds, thus it can call this function
 // instead of relying on #[no_mangle] functions that will conflicts with those defined in REST plugin.
@@ -65,10 +65,10 @@ pub fn get_expected_args2<'a, 'b>() -> Vec<Arg<'a, 'b>> {
     ]
 }
 
-#[no_mangle]
-pub fn start(runtime: Runtime, args: &'static ArgMatches<'_>) {
-    async_std::task::spawn(run(runtime, args.clone()));
-}
+// #[no_mangle]
+// pub fn start(runtime: Runtime, args: &'static ArgMatches<'_>) {
+//     async_std::task::spawn(run(runtime, args.clone()));
+// }
 
 pub async fn run(runtime: Runtime, args: ArgMatches<'_>) {
     // Try to initiate login.

--- a/src/qos.rs
+++ b/src/qos.rs
@@ -1,0 +1,149 @@
+//
+// Copyright (c) 2017, 2020 ADLINK Technology Inc.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ADLINK zenoh team, <zenoh@adlink-labs.tech>
+//
+use cyclors::*;
+use serde::ser::SerializeStruct;
+use serde::{Serialize, Serializer};
+use serde_json::json;
+
+pub const DDS_INFINITE_TIME: i64 = 0x7FFFFFFFFFFFFFFF;
+
+#[derive(Debug)]
+pub struct QosHolder(pub *mut dds_qos_t);
+unsafe impl Send for QosHolder {}
+unsafe impl Sync for QosHolder {}
+
+impl Serialize for QosHolder {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut qos = serializer.serialize_struct("qos", 7)?;
+        #[allow(non_upper_case_globals)]
+        unsafe {
+            // durability
+            let mut dur_kind: dds_durability_kind_t = dds_durability_kind_DDS_DURABILITY_VOLATILE;
+            if dds_qget_durability(self.0, &mut dur_kind) {
+                let d = match dur_kind {
+                    dds_durability_kind_DDS_DURABILITY_VOLATILE => json!({"kind": "VOLATILE"}),
+                    dds_durability_kind_DDS_DURABILITY_TRANSIENT_LOCAL => {
+                        json!({"kind": "TRANSIENT_LOCAL"})
+                    }
+                    dds_durability_kind_DDS_DURABILITY_TRANSIENT => json!({"kind": "TRANSIENT"}),
+                    dds_durability_kind_DDS_DURABILITY_PERSISTENT => json!({"kind": "PERSISTENT"}),
+                    x => json!({ "kind": x }),
+                };
+                qos.serialize_field("durability", &d)?;
+            } else {
+                qos.serialize_field("durability", "FAILED TO RETRIEVE")?;
+            }
+
+            // reliability
+            let mut rel_kind: dds_reliability_kind_t =
+                dds_reliability_kind_DDS_RELIABILITY_BEST_EFFORT;
+            let mut rel_max_blocking_time: dds_duration_t = 0;
+            if dds_qget_reliability(self.0, &mut rel_kind, &mut rel_max_blocking_time) {
+                let k = match rel_kind {
+                    dds_reliability_kind_DDS_RELIABILITY_BEST_EFFORT => {
+                        json!({"kind": "BEST_EFFORT", "max_blocking_time": rel_max_blocking_time})
+                    }
+                    dds_reliability_kind_DDS_RELIABILITY_RELIABLE => {
+                        json!({"kind": "RELIABLE", "max_blocking_time": rel_max_blocking_time})
+                    }
+                    x => {
+                        json!({"kind": x, "max_blocking_time": rel_max_blocking_time})
+                    }
+                };
+                qos.serialize_field("reliability", &k)?;
+            } else {
+                qos.serialize_field("reliability", "FAILED TO RETRIEVE")?;
+            }
+
+            // deadline
+            let mut deadline_period: dds_duration_t = DDS_INFINITE_TIME;
+            dds_qget_deadline(self.0, &mut deadline_period);
+            qos.serialize_field("deadline", &json!({ "period": deadline_period }))?;
+
+            // latency_budget
+            let mut lat_budget: dds_duration_t = 0;
+            dds_qget_latency_budget(self.0, &mut lat_budget);
+            qos.serialize_field("latency_budget", &json!({ "duration": lat_budget }))?;
+
+            // ownership
+            let mut own_kind: dds_ownership_kind_t = dds_ownership_kind_DDS_OWNERSHIP_SHARED;
+            if dds_qget_ownership(self.0, &mut own_kind) {
+                let k = match own_kind {
+                    dds_ownership_kind_DDS_OWNERSHIP_SHARED => {
+                        json!({"kind": "SHARED"})
+                    }
+                    dds_ownership_kind_DDS_OWNERSHIP_EXCLUSIVE => {
+                        json!({"kind": "EXCLUSIVE"})
+                    }
+                    x => {
+                        json!({ "kind": x })
+                    }
+                };
+                qos.serialize_field("ownership", &k)?;
+            } else {
+                qos.serialize_field("ownership", "FAILED TO RETRIEVE")?;
+            }
+
+            // liveliness
+            let mut liv_kind: dds_liveliness_kind_t = dds_liveliness_kind_DDS_LIVELINESS_AUTOMATIC;
+            let mut liv_lease_duration: dds_duration_t = DDS_INFINITE_TIME;
+            if dds_qget_liveliness(self.0, &mut liv_kind, &mut liv_lease_duration) {
+                let k = match liv_kind {
+                    dds_liveliness_kind_DDS_LIVELINESS_AUTOMATIC => {
+                        json!({"kind": "AUTOMATIC", "lease_duration": liv_lease_duration})
+                    }
+                    dds_liveliness_kind_DDS_LIVELINESS_MANUAL_BY_PARTICIPANT => {
+                        json!({"kind": "MANUAL_BY_PARTICIPANT", "lease_duration": liv_lease_duration})
+                    }
+                    dds_liveliness_kind_DDS_LIVELINESS_MANUAL_BY_TOPIC => {
+                        json!({"kind": "MANUAL_BY_TOPIC", "lease_duration": liv_lease_duration})
+                    }
+                    x => {
+                        json!({"kind": x, "lease_duration": liv_lease_duration})
+                    }
+                };
+                qos.serialize_field("liveliness", &k)?;
+            } else {
+                qos.serialize_field("liveliness", "FAILED TO RETRIEVE")?;
+            }
+
+            // destination_order
+            let mut order_kind: dds_destination_order_kind_t =
+                dds_destination_order_kind_DDS_DESTINATIONORDER_BY_RECEPTION_TIMESTAMP;
+            if dds_qget_destination_order(self.0, &mut order_kind) {
+                let k = match order_kind {
+                    dds_destination_order_kind_DDS_DESTINATIONORDER_BY_RECEPTION_TIMESTAMP => {
+                        json!({"kind": "BY_RECEPTION_TIMESTAMP"})
+                    }
+                    dds_destination_order_kind_DDS_DESTINATIONORDER_BY_SOURCE_TIMESTAMP => {
+                        json!({"kind": "BY_SOURCE_TIMESTAMP"})
+                    }
+                    x => {
+                        json!({ "kind": x })
+                    }
+                };
+                qos.serialize_field("destination_order", &k)?;
+            } else {
+                qos.serialize_field("destination_order", "FAILED TO RETRIEVE")?;
+            }
+
+            // (Presentation?)
+        }
+
+        qos.end()
+    }
+}


### PR DESCRIPTION
This PR adds the zenoh REST API to the `zenoh-bridge-dds` (desactivated by default), as well as an adminstration space allowing to browse the discovered DDS entities and the established routes between DDS and zenoh.

It also prepares the code to be release also as a plugin (dynamic library) for the zenoh router, waiting for eclipse-zenoh/zenoh#89 completion.