### PR TITLE
Add Multiarch docker build to github actions

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,0 +1,34 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: vinnnyr/zenoh-plugin-dds:latest


### PR DESCRIPTION
I would like to propose that a multiarch docker image be hosted on the dockerhub. 

This PR contains a github action to do that, but requires a few changes to be hosted in the correct dockerhub organization.

# Testing
To test the PR as it stands right now (right now it is on my personal dockerhub acct)
`docker run --network=host vinnnyr/zenoh-plugin-dds` 

This will work on both `arm` and `x86` type machines. 

# Changes Needed
- Repo maintainers should add their `DOCKERHUB.USERNAME` and their `DOCKERHUB.TOKEN` to the repo secrets using the Github secrets portion
- We must change the line so that it matches the correct dockerhub repo / tag the maintainers would like to use. 


