### PR TITLE
Implement DDS discovery forwarding mode (#33)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 target
 *~
 *.log
+.vscode
 
 # ROS2 packaging
 build

--- a/zenoh-bridge-dds/Cargo.lock
+++ b/zenoh-bridge-dds/Cargo.lock
@@ -24,9 +24,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495ee669413bfbe9e8cace80f4d3d78e6d8c8d99579f97fb93bde351b185f2d4"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher 0.3.0",
@@ -478,9 +478,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cache-padded"
@@ -490,9 +490,9 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
+checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
 
 [[package]]
 name = "cdr"
@@ -559,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cf2cc85830eae84823884db23c5306442a6c3d5bfd3beb2f2a2c829faa1816"
+checksum = "10612c0ec0e0a1ff0e97980647cb058a6e7aedb913d01d009c406b8b7d0b26ee"
 dependencies = [
  "glob",
  "libc",
@@ -648,9 +648,9 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.5"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
  "libc",
 ]
@@ -722,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
+checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
 dependencies = [
  "quote",
  "syn",
@@ -872,15 +872,15 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flume"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e90cc80fad5bb391b38127896b0fa27d97e7fef74742797f4da518d67e1292f"
+checksum = "24c3fd473b3a903a62609e413ed7538f99e10b665ecb502b5e481a95283f8ab4"
 dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
  "pin-project",
- "spinning_top",
+ "spin 0.9.2",
 ]
 
 [[package]]
@@ -895,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
+checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -910,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
+checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -920,15 +920,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
+checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d0d535a57b87e1ae31437b892713aee90cd2d7b0ee48727cd11fc72ef54761c"
+checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -937,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
+checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
 
 [[package]]
 name = "futures-lite"
@@ -958,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
+checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
 dependencies = [
  "autocfg",
  "proc-macro-hack",
@@ -971,21 +971,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
+checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
 
 [[package]]
 name = "futures-task"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
+checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
 
 [[package]]
 name = "futures-util"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
+checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
  "autocfg",
  "futures-channel",
@@ -1257,9 +1257,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "js-sys"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d"
+checksum = "1866b355d9c878e5e607473cbe3f63282c0b7aad2db1dbebf55076c686918254"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1293,9 +1293,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa8cddc8fbbee11227ef194b5317ed014b8acbf15139bd716a18ad3fe99ec5"
+checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "libloading"
@@ -1309,9 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
 dependencies = [
  "scopeguard",
 ]
@@ -1666,9 +1666,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid",
 ]
@@ -1804,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.8.12"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd94b6e266c4d2865f4e514af50a409625291daf7dc914609e0f3415719382d"
+checksum = "2351cbef4bf91837f5ff7face6091cb277ba960d1638d2c5ae2327859912fbba"
 dependencies = [
  "chrono",
  "pem",
@@ -1859,7 +1859,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi",
@@ -1967,9 +1967,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.3.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284"
+checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1998,18 +1998,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.128"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1056a0db1978e9dbf0f6e4fca677f6f9143dc1c19de346f22cac23e422196834"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.128"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13af2fbb8b60a8950d6c72a56d2095c28870367cc8e10c55e9745bac4995a2c4"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2018,9 +2018,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
+checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
 dependencies = [
  "itoa",
  "ryu",
@@ -2058,9 +2058,9 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sha2"
-version = "0.9.5"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
+checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",
@@ -2111,9 +2111,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470c5a6397076fae0094aaf06a08e6ba6f37acb77d3b1b91ea92b4d6c8650c39"
+checksum = "9c98891d737e271a2954825ef19e46bd16bdb98e2746f2eec4f7a4ef7946efd1"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -2171,10 +2171,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "spinning_top"
-version = "0.2.4"
+name = "spin"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75adad84ee84b521fb2cca2d4fd0f1dab1d8d026bda3c5bea4ca63b5f9f9293c"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 dependencies = [
  "lock_api",
 ]
@@ -2263,9 +2263,9 @@ checksum = "45f6ee7c7b87caf59549e9fe45d6a69c75c8019e79e212a835c5da0e92f0ba08"
 
 [[package]]
 name = "syn"
-version = "1.0.75"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
+checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2292,18 +2292,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
+checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2398,9 +2398,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cf844b23c6131f624accf65ce0e4e9956a8bb329400ea5bcc26ae3a5c20b0b"
+checksum = "b4efe6fc2395938c8155973d7be49fe8d03a843726e285e100a8a383cc0154ce"
 dependencies = [
  "autocfg",
  "libc",
@@ -2444,19 +2444,21 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
 name = "uhlc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "766b01176c0b757b0a60e6b5ddeac62efd24e47201abb97b1e39b23d9635791f"
+checksum = "4b39f15111ae3c55bd24b28e2f71e86343ef1d5d16aac8e3faaba8c7a438c881"
 dependencies = [
  "hex",
  "humantime",
+ "lazy_static",
  "log",
+ "serde",
  "uuid",
 ]
 
@@ -2568,9 +2570,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
+checksum = "5e68338db6becec24d3c7977b5bf8a48be992c934b5d07177e3931f5dc9b076c"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -2580,9 +2582,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041"
+checksum = "f34c405b4f0658583dba0c1c7c9b694f3cac32655db463b56c254a1c75269523"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2595,9 +2597,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fded345a6559c2cfee778d562300c581f7d4ff3edb9b0d230d69800d213972"
+checksum = "a87d738d4abc4cf22f6eb142f5b9a81301331ee3c767f2fef2fda4e325492060"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -2607,9 +2609,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef"
+checksum = "b9d5a6580be83b19dc570a8f9c324251687ab2184e57086f71625feb57ec77c8"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2617,9 +2619,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad"
+checksum = "e3775a030dc6f5a0afd8a84981a21cc92a781eb429acef9ecce476d0c9113e92"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2630,15 +2632,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29"
+checksum = "c279e376c7a8e8752a8f1eaa35b7b0bee6bb9fb0cdacfa97cc3f1f289c87e2b4"
 
 [[package]]
 name = "web-sys"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c"
+checksum = "0a84d70d1ec7d2da2d26a5bd78f4bca1b8c3254805363ce743b7a05bc30d195a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2725,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "0.5.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh#000a2ba4681c49fe55fd42bafa5f4b8996c57cd7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#c4e46992c2600e2a56ff17805ab554c1d113f869"
 dependencies = [
  "async-global-executor",
  "async-rustls",
@@ -2780,7 +2782,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "0.5.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh#000a2ba4681c49fe55fd42bafa5f4b8996c57cd7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#c4e46992c2600e2a56ff17805ab554c1d113f869"
 dependencies = [
  "async-std",
  "bincode",
@@ -2797,7 +2799,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-rest"
 version = "0.5.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh#000a2ba4681c49fe55fd42bafa5f4b8996c57cd7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#c4e46992c2600e2a56ff17805ab554c1d113f869"
 dependencies = [
  "async-std",
  "base64 0.13.0",
@@ -2816,7 +2818,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.1.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh#000a2ba4681c49fe55fd42bafa5f4b8996c57cd7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#c4e46992c2600e2a56ff17805ab554c1d113f869"
 dependencies = [
  "clap",
  "libloading",
@@ -2827,9 +2829,9 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.5.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh#000a2ba4681c49fe55fd42bafa5f4b8996c57cd7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#c4e46992c2600e2a56ff17805ab554c1d113f869"
 dependencies = [
- "aes 0.7.4",
+ "aes 0.7.5",
  "async-std",
  "async-trait",
  "clap",

--- a/zenoh-bridge-dds/Cargo.lock
+++ b/zenoh-bridge-dds/Cargo.lock
@@ -471,6 +471,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +493,16 @@ name = "cc"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
+
+[[package]]
+name = "cdr"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9617422bf43fde9280707a7e90f8f7494389c182f5c70b0f67592d0f06d41dfa"
+dependencies = [
+ "byteorder",
+ "serde",
+]
 
 [[package]]
 name = "cexpr"
@@ -2844,6 +2860,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "bincode",
+ "cdr",
  "clap",
  "cyclors",
  "derivative",
@@ -2862,4 +2879,5 @@ dependencies = [
  "zenoh",
  "zenoh-ext",
  "zenoh-plugin-trait",
+ "zenoh-util",
 ]

--- a/zenoh-bridge-dds/Cargo.lock
+++ b/zenoh-bridge-dds/Cargo.lock
@@ -745,6 +745,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2832,9 +2843,12 @@ version = "0.5.0-dev"
 dependencies = [
  "async-std",
  "async-trait",
+ "bincode",
  "clap",
  "cyclors",
+ "derivative",
  "env_logger 0.8.4",
+ "flume",
  "futures",
  "git-version",
  "hex",

--- a/zenoh-bridge-dds/src/main.rs
+++ b/zenoh-bridge-dds/src/main.rs
@@ -35,7 +35,7 @@ fn customize_dds_args<'a, 'b>(mut args: Vec<Arg<'a, 'b>>) -> Vec<Arg<'a, 'b>> {
     args.push(arg);
     let arg = args.remove(0).visible_alias("group-lease");
     args.push(arg);
-    let arg = args.remove(0).visible_alias("fwd-discovery");
+    let arg = args.remove(0).short("f").visible_alias("fwd-discovery");
     args.push(arg);
 
     args

--- a/zenoh-bridge-dds/src/main.rs
+++ b/zenoh-bridge-dds/src/main.rs
@@ -52,6 +52,12 @@ fn parse_args() -> (Properties, bool, ArgMatches<'static>) {
             "-l, --listener=[LOCATOR]...   'Locators to listen on.'",
         ))
         .arg(Arg::from_usage(
+                "-i, --id=[hex_string] \
+            'The identifier (as an hexadecimal string - e.g.: 0A0B23...) that the zenoh bridge must use. \
+            WARNING: this identifier must be unique in the system! \
+            If not set, a random UUIDv4 will be used.'",
+        ))
+        .arg(Arg::from_usage(
             "-c, --config=[FILE]      'A configuration file.'",
         ))
         .arg(
@@ -118,7 +124,7 @@ async fn main() {
     let (config, rest_plugin, args) = parse_args();
 
     // create a zenoh Runtime (to share with plugins)
-    let runtime = zenoh::net::runtime::Runtime::new(0, config.into(), None)
+    let runtime = zenoh::net::runtime::Runtime::new(0, config.into(), args.value_of("id"))
         .await
         .unwrap();
 

--- a/zenoh-bridge-dds/src/main.rs
+++ b/zenoh-bridge-dds/src/main.rs
@@ -18,9 +18,9 @@ use zenoh_plugin_trait::Plugin;
 // customize the DDS plugin args for retro-compatibility with previous versions of the standalone bridge
 fn customize_dds_args<'a, 'b>(mut args: Vec<Arg<'a, 'b>>) -> Vec<Arg<'a, 'b>> {
     // NOTE: no way to check what's each Arg is in the Vec!
-    // We need to assume that there are 7, and that they are in correct order...
+    // We need to assume that there are 8, and that they are in correct order...
     // as specifed in src/lib.rs in get_expected_args()
-    assert_eq!(7, args.len());
+    assert_eq!(8, args.len());
     let arg = args.remove(0).short("s").visible_alias("scope");
     args.push(arg);
     let arg = args.remove(0).short("w").visible_alias("generalise-pub");
@@ -34,6 +34,8 @@ fn customize_dds_args<'a, 'b>(mut args: Vec<Arg<'a, 'b>>) -> Vec<Arg<'a, 'b>> {
     let arg = args.remove(0).visible_alias("group-member-id");
     args.push(arg);
     let arg = args.remove(0).visible_alias("group-lease");
+    args.push(arg);
+    let arg = args.remove(0).visible_alias("fwd-discovery");
     args.push(arg);
 
     args

--- a/zplugin-dds/Cargo.lock
+++ b/zplugin-dds/Cargo.lock
@@ -593,6 +593,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2534,9 +2545,12 @@ version = "0.5.0-dev"
 dependencies = [
  "async-std",
  "async-trait",
+ "bincode",
  "clap",
  "cyclors",
+ "derivative",
  "env_logger 0.8.4",
+ "flume",
  "futures",
  "git-version",
  "hex",

--- a/zplugin-dds/Cargo.lock
+++ b/zplugin-dds/Cargo.lock
@@ -365,6 +365,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +387,16 @@ name = "cc"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
+
+[[package]]
+name = "cdr"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9617422bf43fde9280707a7e90f8f7494389c182f5c70b0f67592d0f06d41dfa"
+dependencies = [
+ "byteorder",
+ "serde",
+]
 
 [[package]]
 name = "cexpr"
@@ -2546,6 +2562,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "bincode",
+ "cdr",
  "clap",
  "cyclors",
  "derivative",
@@ -2564,4 +2581,5 @@ dependencies = [
  "zenoh",
  "zenoh-ext",
  "zenoh-plugin-trait",
+ "zenoh-util",
 ]

--- a/zplugin-dds/Cargo.lock
+++ b/zplugin-dds/Cargo.lock
@@ -24,9 +24,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495ee669413bfbe9e8cace80f4d3d78e6d8c8d99579f97fb93bde351b185f2d4"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if",
  "cipher 0.3.0",
@@ -372,9 +372,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cache-padded"
@@ -384,9 +384,9 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
+checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
 
 [[package]]
 name = "cdr"
@@ -443,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cf2cc85830eae84823884db23c5306442a6c3d5bfd3beb2f2a2c829faa1816"
+checksum = "10612c0ec0e0a1ff0e97980647cb058a6e7aedb913d01d009c406b8b7d0b26ee"
 dependencies = [
  "glob",
  "libc",
@@ -526,9 +526,9 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.5"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
  "libc",
 ]
@@ -580,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
+checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
 dependencies = [
  "quote",
  "syn",
@@ -704,15 +704,15 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flume"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e90cc80fad5bb391b38127896b0fa27d97e7fef74742797f4da518d67e1292f"
+checksum = "24c3fd473b3a903a62609e413ed7538f99e10b665ecb502b5e481a95283f8ab4"
 dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
  "pin-project",
- "spinning_top",
+ "spin 0.9.2",
 ]
 
 [[package]]
@@ -727,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
+checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -742,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
+checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -752,15 +752,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
+checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d0d535a57b87e1ae31437b892713aee90cd2d7b0ee48727cd11fc72ef54761c"
+checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -769,9 +769,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
+checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
 
 [[package]]
 name = "futures-lite"
@@ -790,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
+checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
 dependencies = [
  "autocfg",
  "proc-macro-hack",
@@ -803,21 +803,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
+checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
 
 [[package]]
 name = "futures-task"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
+checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
 
 [[package]]
 name = "futures-util"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
+checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
  "autocfg",
  "futures-channel",
@@ -1060,9 +1060,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "js-sys"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d"
+checksum = "1866b355d9c878e5e607473cbe3f63282c0b7aad2db1dbebf55076c686918254"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1096,9 +1096,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa8cddc8fbbee11227ef194b5317ed014b8acbf15139bd716a18ad3fe99ec5"
+checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "libloading"
@@ -1112,9 +1112,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
 dependencies = [
  "scopeguard",
 ]
@@ -1463,9 +1463,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid",
 ]
@@ -1601,9 +1601,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.8.12"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd94b6e266c4d2865f4e514af50a409625291daf7dc914609e0f3415719382d"
+checksum = "2351cbef4bf91837f5ff7face6091cb277ba960d1638d2c5ae2327859912fbba"
 dependencies = [
  "chrono",
  "pem",
@@ -1656,7 +1656,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi",
@@ -1758,9 +1758,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.3.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284"
+checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1789,18 +1789,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.128"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1056a0db1978e9dbf0f6e4fca677f6f9143dc1c19de346f22cac23e422196834"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.128"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13af2fbb8b60a8950d6c72a56d2095c28870367cc8e10c55e9745bac4995a2c4"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1809,9 +1809,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
+checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
 dependencies = [
  "itoa",
  "ryu",
@@ -1849,9 +1849,9 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sha2"
-version = "0.9.5"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
+checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer",
  "cfg-if",
@@ -1902,9 +1902,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470c5a6397076fae0094aaf06a08e6ba6f37acb77d3b1b91ea92b4d6c8650c39"
+checksum = "9c98891d737e271a2954825ef19e46bd16bdb98e2746f2eec4f7a4ef7946efd1"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -1953,10 +1953,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "spinning_top"
-version = "0.2.4"
+name = "spin"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75adad84ee84b521fb2cca2d4fd0f1dab1d8d026bda3c5bea4ca63b5f9f9293c"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 dependencies = [
  "lock_api",
 ]
@@ -2033,9 +2033,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.75"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
+checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2062,18 +2062,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
+checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2135,9 +2135,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cf844b23c6131f624accf65ce0e4e9956a8bb329400ea5bcc26ae3a5c20b0b"
+checksum = "b4efe6fc2395938c8155973d7be49fe8d03a843726e285e100a8a383cc0154ce"
 dependencies = [
  "autocfg",
  "libc",
@@ -2181,19 +2181,21 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
 name = "uhlc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "766b01176c0b757b0a60e6b5ddeac62efd24e47201abb97b1e39b23d9635791f"
+checksum = "4b39f15111ae3c55bd24b28e2f71e86343ef1d5d16aac8e3faaba8c7a438c881"
 dependencies = [
  "hex",
  "humantime",
+ "lazy_static",
  "log",
+ "serde",
  "uuid",
 ]
 
@@ -2304,9 +2306,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
+checksum = "5e68338db6becec24d3c7977b5bf8a48be992c934b5d07177e3931f5dc9b076c"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2314,9 +2316,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041"
+checksum = "f34c405b4f0658583dba0c1c7c9b694f3cac32655db463b56c254a1c75269523"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2329,9 +2331,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fded345a6559c2cfee778d562300c581f7d4ff3edb9b0d230d69800d213972"
+checksum = "a87d738d4abc4cf22f6eb142f5b9a81301331ee3c767f2fef2fda4e325492060"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2341,9 +2343,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef"
+checksum = "b9d5a6580be83b19dc570a8f9c324251687ab2184e57086f71625feb57ec77c8"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2351,9 +2353,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad"
+checksum = "e3775a030dc6f5a0afd8a84981a21cc92a781eb429acef9ecce476d0c9113e92"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2364,15 +2366,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29"
+checksum = "c279e376c7a8e8752a8f1eaa35b7b0bee6bb9fb0cdacfa97cc3f1f289c87e2b4"
 
 [[package]]
 name = "web-sys"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c"
+checksum = "0a84d70d1ec7d2da2d26a5bd78f4bca1b8c3254805363ce743b7a05bc30d195a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2459,7 +2461,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "0.5.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh#000a2ba4681c49fe55fd42bafa5f4b8996c57cd7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#c4e46992c2600e2a56ff17805ab554c1d113f869"
 dependencies = [
  "async-global-executor",
  "async-rustls",
@@ -2501,7 +2503,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "0.5.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh#000a2ba4681c49fe55fd42bafa5f4b8996c57cd7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#c4e46992c2600e2a56ff17805ab554c1d113f869"
 dependencies = [
  "async-std",
  "bincode",
@@ -2518,7 +2520,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.1.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh#000a2ba4681c49fe55fd42bafa5f4b8996c57cd7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#c4e46992c2600e2a56ff17805ab554c1d113f869"
 dependencies = [
  "clap",
  "libloading",
@@ -2529,9 +2531,9 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.5.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh#000a2ba4681c49fe55fd42bafa5f4b8996c57cd7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#c4e46992c2600e2a56ff17805ab554c1d113f869"
 dependencies = [
- "aes 0.7.4",
+ "aes 0.7.5",
  "async-std",
  "async-trait",
  "clap",

--- a/zplugin-dds/Cargo.toml
+++ b/zplugin-dds/Cargo.toml
@@ -42,6 +42,7 @@ cyclors = "0.1.1"
 log = "0.4.14"
 async-trait = "0.1.42"
 futures = "0.3.12"
+flume = "0.10.8"
 libc = "0.2.85"
 clap = "2.33"
 env_logger = "0.8.2"
@@ -51,6 +52,8 @@ hex = "0.4.3"
 lazy_static = "1.4.0"
 serde = "1.0.125"
 serde_json = "1.0.64"
+bincode = "1.3.3"
+derivative = "2.2.0"
 
 
 [dependencies.async-std]

--- a/zplugin-dds/Cargo.toml
+++ b/zplugin-dds/Cargo.toml
@@ -37,6 +37,7 @@ default = ["no_mangle"]
 [dependencies]
 zenoh = { git = "https://github.com/eclipse-zenoh/zenoh" }
 zenoh-ext = { git = "https://github.com/eclipse-zenoh/zenoh" }
+zenoh-util = { git = "https://github.com/eclipse-zenoh/zenoh" }
 zenoh-plugin-trait = { git = "https://github.com/eclipse-zenoh/zenoh", default-features = false }
 cyclors = "0.1.1"
 log = "0.4.14"
@@ -54,7 +55,7 @@ serde = "1.0.125"
 serde_json = "1.0.64"
 bincode = "1.3.3"
 derivative = "2.2.0"
-
+cdr = "0.2.4"
 
 [dependencies.async-std]
 version = "1.9.0"

--- a/zplugin-dds/src/dds_mgt.rs
+++ b/zplugin-dds/src/dds_mgt.rs
@@ -16,7 +16,7 @@ use async_std::channel::Sender;
 use async_std::task;
 use cyclors::*;
 use log::debug;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::mem::MaybeUninit;
@@ -26,7 +26,7 @@ use zenoh::net::{ResKey, Session, ZBuf};
 
 const MAX_SAMPLES: usize = 32;
 
-#[derive(PartialEq, Debug, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub(crate) enum RouteStatus {
     Routed(String), // Routing is active, String is the zenoh zenoh resource key used for the route
     NotAllowed,     // Routing was not allowed per configuration
@@ -34,7 +34,7 @@ pub(crate) enum RouteStatus {
     _QoSConflict,   // A route was already established but with conflicting QoS
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct DdsEntity {
     pub(crate) key: String,
     pub(crate) participant_key: String,

--- a/zplugin-dds/src/dds_mgt.rs
+++ b/zplugin-dds/src/dds_mgt.rs
@@ -271,3 +271,15 @@ pub fn delete_dds_entity(entity: dds_entity_t) -> Result<(), String> {
         }
     }
 }
+
+pub fn get_guid(entity: &dds_entity_t) -> Result<String, String> {
+    unsafe {
+        let mut guid = dds_guid_t { v: [0; 16] };
+        let r = dds_get_guid(*entity, &mut guid);
+        if r == 0 {
+            Ok(hex::encode(guid.v))
+        } else {
+            Err(format!("Error getting GUID of DDS entity - retcode={}", r))
+        }
+    }
+}

--- a/zplugin-dds/src/qos.rs
+++ b/zplugin-dds/src/qos.rs
@@ -225,6 +225,12 @@ impl Qos {
         unsafe {
             let qos = dds_qos_create();
 
+            // reliability
+            dds_qset_reliability(
+                qos,
+                self.reliability.kind as dds_reliability_kind_t,
+                self.reliability.max_blocking_time,
+            );
             // durability
             dds_qset_durability(qos, self.durability.kind as dds_durability_kind_t);
             // durability service

--- a/zplugin-dds/src/qos.rs
+++ b/zplugin-dds/src/qos.rs
@@ -1,3 +1,8 @@
+use std::{
+    ffi::{CStr, CString},
+    os::raw::c_char,
+};
+
 //
 // Copyright (c) 2017, 2020 ADLINK Technology Inc.
 //
@@ -12,219 +17,504 @@
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
 use cyclors::*;
-use serde::ser::SerializeStruct;
-use serde::{Serialize, Serializer};
-use serde_json::json;
-use std::time::Duration;
+use derivative::Derivative;
+use serde::{Deserialize, Serialize};
+
+use crate::vec_into_raw_parts;
 
 pub const DDS_INFINITE_TIME: i64 = 0x7FFFFFFFFFFFFFFF;
+pub const DDS_100MS_DURATION: i64 = 100 * 1_000_000;
+pub const DDS_1S_DURATION: i64 = 1_000_000_000;
 
-#[derive(Debug)]
-pub struct QosHolder(pub *mut dds_qos_t);
-unsafe impl Send for QosHolder {}
-unsafe impl Sync for QosHolder {}
-
-impl QosHolder {
-    pub fn is_transient_local(&self) -> bool {
-        unsafe {
-            let mut dur_kind: dds_durability_kind_t = dds_durability_kind_DDS_DURABILITY_VOLATILE;
-            dds_qget_durability(self.0, &mut dur_kind)
-                && dur_kind == dds_durability_kind_DDS_DURABILITY_TRANSIENT_LOCAL
-        }
-    }
-
-    pub fn get_history(&self) -> (dds_history_kind_t, i32) {
-        unsafe {
-            let mut hist_kind = dds_history_kind_DDS_HISTORY_KEEP_LAST;
-            let mut hist_depth = 1;
-            dds_qget_history(self.0, &mut hist_kind, &mut hist_depth);
-            (hist_kind, hist_depth)
-        }
-    }
-
-    pub fn set_history(&mut self, kind: dds_history_kind_t, depth: i32) {
-        unsafe {
-            dds_qset_history(self.0, kind, depth);
-        }
-    }
-
-    pub fn set_ignore_local_participant(&mut self) {
-        unsafe {
-            dds_qset_ignorelocal(self.0, dds_ignorelocal_kind_DDS_IGNORELOCAL_PARTICIPANT);
-        }
-    }
-
-    pub fn set_durability_service(
-        &mut self,
-        service_cleanup_delay: &Duration,
-        history_kind: dds_history_kind_t,
-        history_depth: i32,
-        max_samples: i32,
-        max_instances: i32,
-        max_samples_per_instance: i32,
-    ) {
-        let delay: dds_duration_t = service_cleanup_delay.as_nanos() as i64;
-        unsafe {
-            dds_qset_durability_service(
-                self.0,
-                delay,
-                history_kind,
-                history_depth,
-                max_samples,
-                max_instances,
-                max_samples_per_instance,
-            );
-        }
-    }
-
-    pub fn inc_reliability_max_blocking_time(&mut self) {
-        // Workaround for the DDS Writer to correctly match with a FastRTPS Reader declaring a Reliability max_blocking_time < infinite
-        unsafe {
-            let mut rel_kind: dds_reliability_kind_t =
-                dds_reliability_kind_DDS_RELIABILITY_RELIABLE;
-            let mut max_blocking_time: dds_duration_t = 0;
-            if dds_qget_reliability(self.0, &mut rel_kind, &mut max_blocking_time)
-                && max_blocking_time < DDS_INFINITE_TIME
-            {
-                // Add 1 nanosecond to max_blocking_time for the Publisher
-                max_blocking_time += 1;
-                dds_qset_reliability(self.0, rel_kind, max_blocking_time);
-            }
-        }
-    }
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct Qos {
+    pub durability: Durability,
+    pub durability_service: DurabilityService,
+    pub reliability: Reliability,
+    pub deadline: Deadline,
+    pub latency_budget: LatencyBudget,
+    pub ownership: Ownership,
+    pub liveliness: Liveliness,
+    pub destination_order: DestinationOrder,
+    pub history: History,
+    pub partitions: Vec<String>,
+    #[serde(skip)]
+    pub ignore_local_participant: bool,
 }
 
-impl Clone for QosHolder {
-    fn clone(&self) -> Self {
-        unsafe {
-            let qos = dds_create_qos();
-            dds_copy_qos(qos, self.0);
-            QosHolder(qos)
-        }
-    }
-}
-
-impl Serialize for QosHolder {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut qos = serializer.serialize_struct("qos", 7)?;
-        #[allow(non_upper_case_globals)]
+impl Qos {
+    fn from_qos_native_with_reliability(qos: *mut dds_qos_t, reliability: Reliability) -> Self {
         unsafe {
             // durability
             let mut dur_kind: dds_durability_kind_t = dds_durability_kind_DDS_DURABILITY_VOLATILE;
-            if dds_qget_durability(self.0, &mut dur_kind) {
-                let d = match dur_kind {
-                    dds_durability_kind_DDS_DURABILITY_VOLATILE => json!({"kind": "VOLATILE"}),
-                    dds_durability_kind_DDS_DURABILITY_TRANSIENT_LOCAL => {
-                        json!({"kind": "TRANSIENT_LOCAL"})
-                    }
-                    dds_durability_kind_DDS_DURABILITY_TRANSIENT => json!({"kind": "TRANSIENT"}),
-                    dds_durability_kind_DDS_DURABILITY_PERSISTENT => json!({"kind": "PERSISTENT"}),
-                    x => json!({ "kind": x }),
-                };
-                qos.serialize_field("durability", &d)?;
+            let durability = if dds_qget_durability(qos, &mut dur_kind) {
+                Durability {
+                    kind: DurabilityKind::from(&dur_kind),
+                }
             } else {
-                qos.serialize_field("durability", "FAILED TO RETRIEVE")?;
-            }
+                Durability::default()
+            };
 
-            // reliability
-            let mut rel_kind: dds_reliability_kind_t =
-                dds_reliability_kind_DDS_RELIABILITY_BEST_EFFORT;
-            let mut rel_max_blocking_time: dds_duration_t = 0;
-            if dds_qget_reliability(self.0, &mut rel_kind, &mut rel_max_blocking_time) {
-                let k = match rel_kind {
-                    dds_reliability_kind_DDS_RELIABILITY_BEST_EFFORT => {
-                        json!({"kind": "BEST_EFFORT", "max_blocking_time": rel_max_blocking_time})
-                    }
-                    dds_reliability_kind_DDS_RELIABILITY_RELIABLE => {
-                        json!({"kind": "RELIABLE", "max_blocking_time": rel_max_blocking_time})
-                    }
-                    x => {
-                        json!({"kind": x, "max_blocking_time": rel_max_blocking_time})
-                    }
-                };
-                qos.serialize_field("reliability", &k)?;
+            // durability service
+            let mut service_cleanup_delay: dds_duration_t = 0;
+            let mut history_kind: dds_history_kind_t = dds_history_kind_DDS_HISTORY_KEEP_LAST;
+            let mut history_depth = 1i32;
+            let mut max_samples = i32::MAX;
+            let mut max_instances = i32::MAX;
+            let mut max_samples_per_instance = i32::MAX;
+            let durability_service = if dds_qget_durability_service(
+                qos,
+                &mut service_cleanup_delay,
+                &mut history_kind,
+                &mut history_depth,
+                &mut max_samples,
+                &mut max_instances,
+                &mut max_samples_per_instance,
+            ) {
+                DurabilityService {
+                    service_cleanup_delay,
+                    history_kind: HistoryKind::from(&history_kind),
+                    history_depth,
+                    max_samples,
+                    max_instances,
+                    max_samples_per_instance,
+                }
             } else {
-                qos.serialize_field("reliability", "FAILED TO RETRIEVE")?;
-            }
+                DurabilityService::default()
+            };
 
             // deadline
             let mut deadline_period: dds_duration_t = DDS_INFINITE_TIME;
-            dds_qget_deadline(self.0, &mut deadline_period);
-            qos.serialize_field("deadline", &json!({ "period": deadline_period }))?;
+            let deadline = if dds_qget_deadline(qos, &mut deadline_period) {
+                Deadline {
+                    period: deadline_period,
+                }
+            } else {
+                Deadline::default()
+            };
 
             // latency_budget
-            let mut lat_budget: dds_duration_t = 0;
-            dds_qget_latency_budget(self.0, &mut lat_budget);
-            qos.serialize_field("latency_budget", &json!({ "duration": lat_budget }))?;
+            let mut lat_budget_dur: dds_duration_t = 0;
+            let latency_budget = if dds_qget_latency_budget(qos, &mut lat_budget_dur) {
+                LatencyBudget {
+                    duration: lat_budget_dur,
+                }
+            } else {
+                LatencyBudget::default()
+            };
 
             // ownership
             let mut own_kind: dds_ownership_kind_t = dds_ownership_kind_DDS_OWNERSHIP_SHARED;
-            if dds_qget_ownership(self.0, &mut own_kind) {
-                let k = match own_kind {
-                    dds_ownership_kind_DDS_OWNERSHIP_SHARED => {
-                        json!({"kind": "SHARED"})
-                    }
-                    dds_ownership_kind_DDS_OWNERSHIP_EXCLUSIVE => {
-                        json!({"kind": "EXCLUSIVE"})
-                    }
-                    x => {
-                        json!({ "kind": x })
-                    }
-                };
-                qos.serialize_field("ownership", &k)?;
+            let ownership = if dds_qget_ownership(qos, &mut own_kind) {
+                Ownership {
+                    kind: OwnershipKind::from(&own_kind),
+                }
             } else {
-                qos.serialize_field("ownership", "FAILED TO RETRIEVE")?;
-            }
+                Ownership::default()
+            };
 
             // liveliness
             let mut liv_kind: dds_liveliness_kind_t = dds_liveliness_kind_DDS_LIVELINESS_AUTOMATIC;
             let mut liv_lease_duration: dds_duration_t = DDS_INFINITE_TIME;
-            if dds_qget_liveliness(self.0, &mut liv_kind, &mut liv_lease_duration) {
-                let k = match liv_kind {
-                    dds_liveliness_kind_DDS_LIVELINESS_AUTOMATIC => {
-                        json!({"kind": "AUTOMATIC", "lease_duration": liv_lease_duration})
-                    }
-                    dds_liveliness_kind_DDS_LIVELINESS_MANUAL_BY_PARTICIPANT => {
-                        json!({"kind": "MANUAL_BY_PARTICIPANT", "lease_duration": liv_lease_duration})
-                    }
-                    dds_liveliness_kind_DDS_LIVELINESS_MANUAL_BY_TOPIC => {
-                        json!({"kind": "MANUAL_BY_TOPIC", "lease_duration": liv_lease_duration})
-                    }
-                    x => {
-                        json!({"kind": x, "lease_duration": liv_lease_duration})
-                    }
-                };
-                qos.serialize_field("liveliness", &k)?;
+            let liveliness = if dds_qget_liveliness(qos, &mut liv_kind, &mut liv_lease_duration) {
+                Liveliness {
+                    kind: LivelinessKind::from(&liv_kind),
+                    lease_duration: liv_lease_duration,
+                }
             } else {
-                qos.serialize_field("liveliness", "FAILED TO RETRIEVE")?;
-            }
+                Liveliness::default()
+            };
 
             // destination_order
             let mut order_kind: dds_destination_order_kind_t =
                 dds_destination_order_kind_DDS_DESTINATIONORDER_BY_RECEPTION_TIMESTAMP;
-            if dds_qget_destination_order(self.0, &mut order_kind) {
-                let k = match order_kind {
-                    dds_destination_order_kind_DDS_DESTINATIONORDER_BY_RECEPTION_TIMESTAMP => {
-                        json!({"kind": "BY_RECEPTION_TIMESTAMP"})
-                    }
-                    dds_destination_order_kind_DDS_DESTINATIONORDER_BY_SOURCE_TIMESTAMP => {
-                        json!({"kind": "BY_SOURCE_TIMESTAMP"})
-                    }
-                    x => {
-                        json!({ "kind": x })
-                    }
-                };
-                qos.serialize_field("destination_order", &k)?;
+            let destination_order = if dds_qget_destination_order(qos, &mut order_kind) {
+                DestinationOrder {
+                    kind: DestinationOrderKind::from(&order_kind),
+                }
             } else {
-                qos.serialize_field("destination_order", "FAILED TO RETRIEVE")?;
+                DestinationOrder::default()
+            };
+
+            // history
+            let mut hist_kind: dds_history_kind_t = dds_history_kind_DDS_HISTORY_KEEP_LAST;
+            let mut hist_depth: i32 = 1;
+            let history = if dds_qget_history(qos, &mut hist_kind, &mut hist_depth) {
+                let kind = HistoryKind::from(&hist_kind);
+                History {
+                    kind,
+                    depth: hist_depth,
+                }
+            } else {
+                History::default()
+            };
+
+            // partitions
+            let mut n = 0u32;
+            let mut ps: *mut *mut ::std::os::raw::c_char = std::ptr::null_mut();
+            let _ = dds_qget_partition(
+                qos,
+                &mut n as *mut u32,
+                &mut ps as *mut *mut *mut ::std::os::raw::c_char,
+            );
+            let mut partitions: Vec<String> = Vec::with_capacity(n as usize);
+            for k in 0..n {
+                let p = CStr::from_ptr(*(ps.offset(k as isize))).to_str().unwrap();
+                partitions.push(String::from(p));
             }
 
-            // (Presentation?)
+            Self {
+                durability,
+                durability_service,
+                reliability,
+                deadline,
+                latency_budget,
+                ownership,
+                liveliness,
+                destination_order,
+                history,
+                partitions,
+                ignore_local_participant: false,
+            }
         }
-
-        qos.end()
     }
+
+    pub fn from_writer_qos_native(qos: *mut dds_qos_t) -> Self {
+        unsafe {
+            // try to get reliability, defaulting to RELIABLE for a Writer
+            let mut rel_kind: dds_reliability_kind_t = 0;
+            let mut rel_max_blocking_time: dds_duration_t = 0;
+            let reliability =
+                if dds_qget_reliability(qos, &mut rel_kind, &mut rel_max_blocking_time) {
+                    Reliability {
+                        kind: ReliabilityKind::from(&rel_kind),
+                        max_blocking_time: rel_max_blocking_time,
+                    }
+                } else {
+                    Reliability {
+                        kind: ReliabilityKind::RELIABLE,
+                        max_blocking_time: DDS_100MS_DURATION,
+                    }
+                };
+            Self::from_qos_native_with_reliability(qos, reliability)
+        }
+    }
+
+    pub fn from_reader_qos_native(qos: *mut dds_qos_t) -> Self {
+        unsafe {
+            // try to get reliability, defaulting to BEST_EFFORT for a Reader
+            let mut rel_kind: dds_reliability_kind_t = 0;
+            let mut rel_max_blocking_time: dds_duration_t = 0;
+            let reliability =
+                if dds_qget_reliability(qos, &mut rel_kind, &mut rel_max_blocking_time) {
+                    Reliability {
+                        kind: ReliabilityKind::from(&rel_kind),
+                        max_blocking_time: rel_max_blocking_time,
+                    }
+                } else {
+                    Reliability {
+                        kind: ReliabilityKind::BEST_EFFORT,
+                        max_blocking_time: DDS_100MS_DURATION,
+                    }
+                };
+            Self::from_qos_native_with_reliability(qos, reliability)
+        }
+    }
+
+    pub fn to_qos_native(&self) -> *mut dds_qos_t {
+        unsafe {
+            let qos = dds_qos_create();
+
+            // durability
+            dds_qset_durability(qos, self.durability.kind as dds_durability_kind_t);
+            // durability service
+            dds_qset_durability_service(
+                qos,
+                self.durability_service.service_cleanup_delay,
+                self.durability_service.history_kind as dds_history_kind_t,
+                self.durability_service.history_depth,
+                self.durability_service.max_samples,
+                self.durability_service.max_instances,
+                self.durability_service.max_samples_per_instance,
+            );
+            // deadline
+            dds_qset_deadline(qos, self.deadline.period);
+            // latency_budget
+            dds_qset_latency_budget(qos, self.latency_budget.duration);
+            // ownership
+            dds_qset_ownership(qos, self.ownership.kind as dds_ownership_kind_t);
+            // liveliness
+            dds_qset_liveliness(
+                qos,
+                self.liveliness.kind as dds_liveliness_kind_t,
+                self.liveliness.lease_duration,
+            );
+            // destination_order
+            dds_qset_destination_order(
+                qos,
+                self.destination_order.kind as dds_destination_order_kind_t,
+            );
+            // history
+            dds_qset_history(
+                qos,
+                self.history.kind as dds_history_kind_t,
+                self.history.depth,
+            );
+            // partitions
+            if !self.partitions.is_empty() {
+                let mut vcs: Vec<CString> = Vec::with_capacity(self.partitions.len());
+                let mut vptr: Vec<*const c_char> = Vec::with_capacity(self.partitions.len());
+                for p in &self.partitions {
+                    let cs = CString::new(p.as_str()).unwrap();
+                    vptr.push(cs.as_ptr());
+                    vcs.push(cs);
+                }
+                let (ptr, len, cap) = vec_into_raw_parts(vptr);
+                dds_qset_partition(qos, len as u32, ptr);
+                drop(Vec::from_raw_parts(ptr, len, cap));
+            }
+            // ignore_local_participant
+            if self.ignore_local_participant {
+                dds_qset_ignorelocal(qos, dds_ignorelocal_kind_DDS_IGNORELOCAL_PARTICIPANT);
+            }
+            qos
+        }
+    }
+
+    pub fn delete_qos_native(qos: *mut dds_qos_t) {
+        unsafe {
+            dds_delete_qos(qos);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Derivative)]
+#[derivative(Default)]
+pub struct Durability {
+    #[derivative(Default(value = "DurabilityKind::VOLATILE"))]
+    pub kind: DurabilityKind,
+}
+
+#[derive(Debug, Copy, Clone, Deserialize, Serialize, PartialEq)]
+#[allow(non_camel_case_types)]
+pub enum DurabilityKind {
+    VOLATILE = dds_durability_kind_DDS_DURABILITY_VOLATILE as isize,
+    TRANSIENT_LOCAL = dds_durability_kind_DDS_DURABILITY_TRANSIENT_LOCAL as isize,
+    TRANSIENT = dds_durability_kind_DDS_DURABILITY_TRANSIENT as isize,
+    PERSISTENT = dds_durability_kind_DDS_DURABILITY_PERSISTENT as isize,
+}
+
+impl From<&dds_durability_kind_t> for DurabilityKind {
+    fn from(from: &dds_durability_kind_t) -> Self {
+        #[allow(non_upper_case_globals)]
+        match from {
+            &dds_durability_kind_DDS_DURABILITY_VOLATILE => DurabilityKind::VOLATILE,
+            &dds_durability_kind_DDS_DURABILITY_TRANSIENT_LOCAL => DurabilityKind::TRANSIENT_LOCAL,
+            &dds_durability_kind_DDS_DURABILITY_TRANSIENT => DurabilityKind::TRANSIENT,
+            &dds_durability_kind_DDS_DURABILITY_PERSISTENT => DurabilityKind::PERSISTENT,
+            x => panic!("Invalid numeric value for DurabilityKind: {}", x),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Derivative)]
+#[derivative(Default)]
+pub struct DurabilityService {
+    #[derivative(Default(value = "0"))]
+    pub service_cleanup_delay: dds_duration_t,
+    #[derivative(Default(value = "HistoryKind::KEEP_LAST"))]
+    pub history_kind: HistoryKind,
+    #[derivative(Default(value = "1"))]
+    pub history_depth: i32,
+    #[derivative(Default(value = "i32::MAX"))]
+    pub max_samples: i32,
+    #[derivative(Default(value = "i32::MAX"))]
+    pub max_instances: i32,
+    #[derivative(Default(value = "i32::MAX"))]
+    pub max_samples_per_instance: i32,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct Reliability {
+    pub kind: ReliabilityKind,
+    pub max_blocking_time: dds_duration_t,
+}
+
+#[derive(Debug, Copy, Clone, Deserialize, Serialize, PartialEq)]
+#[allow(non_camel_case_types)]
+pub enum ReliabilityKind {
+    BEST_EFFORT = dds_reliability_kind_DDS_RELIABILITY_BEST_EFFORT as isize,
+    RELIABLE = dds_reliability_kind_DDS_RELIABILITY_RELIABLE as isize,
+}
+
+impl From<&dds_reliability_kind_t> for ReliabilityKind {
+    fn from(from: &dds_reliability_kind_t) -> Self {
+        #[allow(non_upper_case_globals)]
+        match from {
+            &dds_reliability_kind_DDS_RELIABILITY_BEST_EFFORT => ReliabilityKind::BEST_EFFORT,
+            &dds_reliability_kind_DDS_RELIABILITY_RELIABLE => ReliabilityKind::RELIABLE,
+            x => panic!("Invalid numeric value for ReliabilityKind: {}", x),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Derivative)]
+#[derivative(Default)]
+pub struct Deadline {
+    #[derivative(Default(value = "DDS_INFINITE_TIME"))]
+    pub period: dds_duration_t,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Derivative)]
+#[derivative(Default)]
+pub struct LatencyBudget {
+    #[derivative(Default(value = "0"))]
+    pub duration: dds_duration_t,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Derivative)]
+#[derivative(Default)]
+pub struct DestinationOrder {
+    #[derivative(Default(value = "DestinationOrderKind::BY_RECEPTION_TIMESTAMP"))]
+    pub kind: DestinationOrderKind,
+}
+
+#[derive(Debug, Copy, Clone, Deserialize, Serialize, PartialEq)]
+#[allow(non_camel_case_types)]
+pub enum DestinationOrderKind {
+    BY_RECEPTION_TIMESTAMP =
+        dds_destination_order_kind_DDS_DESTINATIONORDER_BY_RECEPTION_TIMESTAMP as isize,
+    BY_SOURCE_TIMESTAMP =
+        dds_destination_order_kind_DDS_DESTINATIONORDER_BY_SOURCE_TIMESTAMP as isize,
+}
+
+impl From<&dds_destination_order_kind_t> for DestinationOrderKind {
+    fn from(from: &dds_ownership_kind_t) -> Self {
+        #[allow(non_upper_case_globals)]
+        match from {
+            &dds_destination_order_kind_DDS_DESTINATIONORDER_BY_RECEPTION_TIMESTAMP => {
+                DestinationOrderKind::BY_RECEPTION_TIMESTAMP
+            }
+            &dds_destination_order_kind_DDS_DESTINATIONORDER_BY_SOURCE_TIMESTAMP => {
+                DestinationOrderKind::BY_SOURCE_TIMESTAMP
+            }
+            x => panic!("Invalid numeric value for DestinationOrderKind: {}", x),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Derivative)]
+#[derivative(Default)]
+pub struct Liveliness {
+    #[derivative(Default(value = "LivelinessKind::AUTOMATIC"))]
+    pub kind: LivelinessKind,
+    #[derivative(Default(value = "DDS_INFINITE_TIME"))]
+    pub lease_duration: dds_duration_t,
+}
+
+#[derive(Debug, Copy, Clone, Deserialize, Serialize, PartialEq)]
+#[allow(non_camel_case_types)]
+pub enum LivelinessKind {
+    AUTOMATIC = dds_liveliness_kind_DDS_LIVELINESS_AUTOMATIC as isize,
+    MANUAL_BY_PARTICIPANT = dds_liveliness_kind_DDS_LIVELINESS_MANUAL_BY_PARTICIPANT as isize,
+    MANUAL_BY_TOPIC = dds_liveliness_kind_DDS_LIVELINESS_MANUAL_BY_TOPIC as isize,
+}
+
+impl From<&dds_liveliness_kind_t> for LivelinessKind {
+    fn from(from: &dds_reliability_kind_t) -> Self {
+        #[allow(non_upper_case_globals)]
+        match from {
+            &dds_liveliness_kind_DDS_LIVELINESS_AUTOMATIC => LivelinessKind::AUTOMATIC,
+            &dds_liveliness_kind_DDS_LIVELINESS_MANUAL_BY_PARTICIPANT => {
+                LivelinessKind::MANUAL_BY_PARTICIPANT
+            }
+            &dds_liveliness_kind_DDS_LIVELINESS_MANUAL_BY_TOPIC => LivelinessKind::MANUAL_BY_TOPIC,
+            x => panic!("Invalid numeric value for ReliabilityKind: {}", x),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Derivative)]
+#[derivative(Default)]
+pub struct Ownership {
+    #[derivative(Default(value = "OwnershipKind::SHARED"))]
+    pub kind: OwnershipKind,
+}
+
+#[derive(Debug, Copy, Clone, Deserialize, Serialize, PartialEq)]
+pub enum OwnershipKind {
+    SHARED = dds_ownership_kind_DDS_OWNERSHIP_SHARED as isize,
+    EXCLUSIVE = dds_ownership_kind_DDS_OWNERSHIP_EXCLUSIVE as isize,
+}
+
+impl From<&dds_ownership_kind_t> for OwnershipKind {
+    fn from(from: &dds_ownership_kind_t) -> Self {
+        #[allow(non_upper_case_globals)]
+        match from {
+            &dds_ownership_kind_DDS_OWNERSHIP_SHARED => OwnershipKind::SHARED,
+            &dds_ownership_kind_DDS_OWNERSHIP_EXCLUSIVE => OwnershipKind::EXCLUSIVE,
+            x => panic!("Invalid numeric value for OwnershipKind: {}", x),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Derivative)]
+#[derivative(Default)]
+pub struct History {
+    #[derivative(Default(value = "HistoryKind::KEEP_LAST"))]
+    pub kind: HistoryKind,
+    #[derivative(Default(value = "1"))]
+    pub depth: i32,
+}
+
+#[derive(Debug, Copy, Clone, Deserialize, Serialize, PartialEq)]
+#[allow(non_camel_case_types)]
+pub enum HistoryKind {
+    KEEP_LAST = dds_history_kind_DDS_HISTORY_KEEP_LAST as isize,
+    KEEP_ALL = dds_history_kind_DDS_HISTORY_KEEP_ALL as isize,
+}
+
+impl From<&dds_history_kind_t> for HistoryKind {
+    fn from(from: &dds_history_kind_t) -> Self {
+        #[allow(non_upper_case_globals)]
+        match from {
+            &dds_history_kind_DDS_HISTORY_KEEP_LAST => HistoryKind::KEEP_LAST,
+            &dds_history_kind_DDS_HISTORY_KEEP_ALL => HistoryKind::KEEP_ALL,
+            x => panic!("Invalid numeric value for HistoryKind: {}", x),
+        }
+    }
+}
+
+#[test]
+fn test_qos_serialization() {
+    let native = unsafe { dds_create_qos() };
+    let qos = Qos::from_writer_qos_native(native);
+    let json = serde_json::to_string(&qos).unwrap();
+
+    println!("{}", json);
+    let qos2 = serde_json::from_str::<Qos>(&json).unwrap();
+    assert!(qos == qos2);
+
+    let bincode = bincode::serialize(&qos).unwrap();
+    println!("len={} : {:x?}", bincode.len(), &bincode);
+    let qos3 = bincode::deserialize::<Qos>(&bincode).unwrap();
+    assert!(qos == qos3);
+}
+
+#[test]
+fn test_to_native() {
+    let native = unsafe { dds_create_qos() };
+    let mut qos = Qos::from_writer_qos_native(native);
+
+    let native2 = qos.to_qos_native();
+    let qos2 = Qos::from_writer_qos_native(native2);
+    assert!(qos == qos2);
+
+    qos.partitions.push("P1".to_string());
+    qos.partitions.push("P2".to_string());
+
+    let native3 = qos.to_qos_native();
+    let qos3 = Qos::from_writer_qos_native(native3);
+    assert!(qos3.partitions.len() == 2);
+    assert!(qos == qos3);
 }

--- a/zplugin-dds/src/qos.rs
+++ b/zplugin-dds/src/qos.rs
@@ -311,7 +311,7 @@ pub struct Durability {
 }
 
 #[derive(Debug, Copy, Clone, Deserialize, Serialize, PartialEq)]
-#[allow(non_camel_case_types)]
+#[allow(non_camel_case_types, clippy::upper_case_acronyms)]
 pub enum DurabilityKind {
     VOLATILE = dds_durability_kind_DDS_DURABILITY_VOLATILE as isize,
     TRANSIENT_LOCAL = dds_durability_kind_DDS_DURABILITY_TRANSIENT_LOCAL as isize,
@@ -356,7 +356,7 @@ pub struct Reliability {
 }
 
 #[derive(Debug, Copy, Clone, Deserialize, Serialize, PartialEq)]
-#[allow(non_camel_case_types)]
+#[allow(non_camel_case_types, clippy::upper_case_acronyms)]
 pub enum ReliabilityKind {
     BEST_EFFORT = dds_reliability_kind_DDS_RELIABILITY_BEST_EFFORT as isize,
     RELIABLE = dds_reliability_kind_DDS_RELIABILITY_RELIABLE as isize,
@@ -395,7 +395,7 @@ pub struct DestinationOrder {
 }
 
 #[derive(Debug, Copy, Clone, Deserialize, Serialize, PartialEq)]
-#[allow(non_camel_case_types)]
+#[allow(non_camel_case_types, clippy::upper_case_acronyms)]
 pub enum DestinationOrderKind {
     BY_RECEPTION_TIMESTAMP =
         dds_destination_order_kind_DDS_DESTINATIONORDER_BY_RECEPTION_TIMESTAMP as isize,
@@ -428,7 +428,7 @@ pub struct Liveliness {
 }
 
 #[derive(Debug, Copy, Clone, Deserialize, Serialize, PartialEq)]
-#[allow(non_camel_case_types)]
+#[allow(non_camel_case_types, clippy::upper_case_acronyms)]
 pub enum LivelinessKind {
     AUTOMATIC = dds_liveliness_kind_DDS_LIVELINESS_AUTOMATIC as isize,
     MANUAL_BY_PARTICIPANT = dds_liveliness_kind_DDS_LIVELINESS_MANUAL_BY_PARTICIPANT as isize,
@@ -457,6 +457,7 @@ pub struct Ownership {
 }
 
 #[derive(Debug, Copy, Clone, Deserialize, Serialize, PartialEq)]
+#[allow(non_camel_case_types, clippy::upper_case_acronyms)]
 pub enum OwnershipKind {
     SHARED = dds_ownership_kind_DDS_OWNERSHIP_SHARED as isize,
     EXCLUSIVE = dds_ownership_kind_DDS_OWNERSHIP_EXCLUSIVE as isize,

--- a/zplugin-dds/src/qos.rs
+++ b/zplugin-dds/src/qos.rs
@@ -294,6 +294,15 @@ impl Qos {
     }
 }
 
+impl Default for Qos {
+    fn default() -> Self {
+        unsafe {
+            let qos = dds_qos_create();
+            Qos::from_reader_qos_native(qos)
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Derivative)]
 #[derivative(Default)]
 pub struct Durability {

--- a/zplugin-dds/src/ros_discovery.rs
+++ b/zplugin-dds/src/ros_discovery.rs
@@ -127,7 +127,7 @@ impl RosDiscoveryInfoMgr {
         }
     }
 
-    pub(crate) fn read(&self) -> Vec<ZBuf> {
+    pub(crate) fn read(&self) -> HashMap<String, ZBuf> {
         unsafe {
             let mut zp: *mut cdds_ddsi_payload = std::ptr::null_mut();
             #[allow(clippy::uninit_assumed_init)]
@@ -150,7 +150,7 @@ impl RosDiscoveryInfoMgr {
                 }
                 cdds_serdata_unref(zp as *mut ddsi_serdata);
             }
-            result.into_values().collect()
+            result
         }
     }
 
@@ -187,7 +187,7 @@ impl RosDiscoveryInfoMgr {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub(crate) struct NodesEntitieInfo {
     pub node_namespace: String,
     pub node_name: String,
@@ -217,7 +217,7 @@ impl std::fmt::Display for NodesEntitieInfo {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub(crate) struct ParticipantEntitiesInfo {
     #[serde(serialize_with = "serialize_gid", deserialize_with = "deserialize_gid")]
     pub gid: String,
@@ -235,7 +235,7 @@ impl std::fmt::Display for ParticipantEntitiesInfo {
     }
 }
 
-fn serialize_gid<S>(gid: &String, serializer: S) -> Result<S::Ok, S::Error>
+fn serialize_gid<S>(gid: &str, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
@@ -257,7 +257,7 @@ where
     Ok(hex::encode(&gid[..16]))
 }
 
-fn serialize_gids<S>(gids: &Vec<String>, serializer: S) -> Result<S::Ok, S::Error>
+fn serialize_gids<S>(gids: &[String], serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {

--- a/zplugin-dds/src/ros_discovery.rs
+++ b/zplugin-dds/src/ros_discovery.rs
@@ -1,0 +1,277 @@
+//
+// Copyright (c) 2017, 2020 ADLINK Technology Inc.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ADLINK zenoh team, <zenoh@adlink-labs.tech>
+//
+use crate::dds_mgt::delete_dds_entity;
+use crate::qos::{Durability, History, Qos, Reliability, DDS_INFINITE_TIME};
+use cdr::{CdrLe, Infinite};
+use cyclors::*;
+use log::warn;
+use serde::ser::SerializeSeq;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{
+    collections::HashMap,
+    ffi::{CStr, CString},
+    mem::MaybeUninit,
+};
+use zenoh::net::ZBuf;
+
+pub(crate) const ROS_DISCOVERY_INFO_TOPIC_NAME: &str = "ros_discovery_info";
+const ROS_DISCOVERY_INFO_TOPIC_TYPE: &str = "rmw_dds_common::msg::dds_::ParticipantEntitiesInfo_";
+
+pub(crate) struct RosDiscoveryInfoMgr {
+    participant: dds_entity_t,
+    reader: dds_entity_t,
+    writer: dds_entity_t,
+}
+
+impl Drop for RosDiscoveryInfoMgr {
+    fn drop(&mut self) {
+        if let Err(e) = delete_dds_entity(self.reader) {
+            warn!(
+                "Error dropping DDS reader on {}: {}",
+                ROS_DISCOVERY_INFO_TOPIC_NAME, e
+            );
+        }
+        if let Err(e) = delete_dds_entity(self.writer) {
+            warn!(
+                "Error dropping DDS writer on {}: {}",
+                ROS_DISCOVERY_INFO_TOPIC_NAME, e
+            );
+        }
+    }
+}
+
+impl RosDiscoveryInfoMgr {
+    pub(crate) fn create(participant: dds_entity_t) -> Result<RosDiscoveryInfoMgr, String> {
+        let cton = CString::new(ROS_DISCOVERY_INFO_TOPIC_NAME)
+            .unwrap()
+            .into_raw();
+        let ctyn = CString::new(ROS_DISCOVERY_INFO_TOPIC_TYPE)
+            .unwrap()
+            .into_raw();
+
+        unsafe {
+            // Create topic (for reader/writer creation)
+            let t = cdds_create_blob_topic(participant, cton, ctyn, true);
+
+            // Create reader
+            let mut qos = Qos::default();
+            qos.reliability = Reliability {
+                kind: crate::qos::ReliabilityKind::RELIABLE,
+                max_blocking_time: DDS_INFINITE_TIME,
+            };
+            qos.durability = Durability {
+                kind: crate::qos::DurabilityKind::TRANSIENT_LOCAL,
+            };
+            // Note: KEEP_ALL to not loose any sample (topic is keyless). A periodic task should take samples from history.
+            qos.history = History {
+                kind: crate::qos::HistoryKind::KEEP_ALL,
+                depth: 0,
+            };
+            qos.ignore_local_participant = true;
+            let qos_native = qos.to_qos_native();
+            let reader = dds_create_reader(participant, t, qos_native, std::ptr::null());
+            Qos::delete_qos_native(qos_native);
+            if reader < 0 {
+                return Err(format!(
+                    "Error creating DDS Reader on {}: {}",
+                    ROS_DISCOVERY_INFO_TOPIC_NAME,
+                    CStr::from_ptr(dds_strretcode(-reader)).to_str().unwrap()
+                ));
+            }
+
+            // Create writer
+            let mut qos = Qos::default();
+            qos.reliability = Reliability {
+                kind: crate::qos::ReliabilityKind::RELIABLE,
+                max_blocking_time: DDS_INFINITE_TIME,
+            };
+            qos.durability = Durability {
+                kind: crate::qos::DurabilityKind::TRANSIENT_LOCAL,
+            };
+            qos.history = History {
+                kind: crate::qos::HistoryKind::KEEP_LAST,
+                depth: 1,
+            };
+            qos.ignore_local_participant = true;
+            let qos_native = qos.to_qos_native();
+            let writer = dds_create_writer(participant, t, qos_native, std::ptr::null());
+            Qos::delete_qos_native(qos_native);
+            if reader < 0 {
+                return Err(format!(
+                    "Error creating DDS Writer on {}: {}",
+                    ROS_DISCOVERY_INFO_TOPIC_NAME,
+                    CStr::from_ptr(dds_strretcode(-reader)).to_str().unwrap()
+                ));
+            }
+
+            drop(CString::from_raw(cton));
+            drop(CString::from_raw(ctyn));
+
+            Ok(RosDiscoveryInfoMgr {
+                participant,
+                reader,
+                writer,
+            })
+        }
+    }
+
+    pub(crate) fn read(&self) -> Vec<ZBuf> {
+        unsafe {
+            let mut zp: *mut cdds_ddsi_payload = std::ptr::null_mut();
+            #[allow(clippy::uninit_assumed_init)]
+            let mut si: [dds_sample_info_t; 1] = { MaybeUninit::uninit().assume_init() };
+            // Place read samples into a map indexed by Participant gid. Thus we only keep the last update for each
+            let mut result: HashMap<String, ZBuf> = HashMap::new();
+            while cdds_take_blob(self.reader, &mut zp, si.as_mut_ptr()) > 0 {
+                if si[0].valid_data {
+                    let bs = Vec::from_raw_parts(
+                        (*zp).payload,
+                        (*zp).size as usize,
+                        (*zp).size as usize,
+                    );
+                    // No need to deserialize the full payload. Just read the Participant gid (16 bytes after the 4 bytes of CDR header)
+                    let gid = hex::encode(&bs[4..20]);
+                    let buf = ZBuf::from(bs);
+                    result.insert(gid, buf);
+
+                    (*zp).payload = std::ptr::null_mut();
+                }
+                cdds_serdata_unref(zp as *mut ddsi_serdata);
+            }
+            result.into_values().collect()
+        }
+    }
+
+    pub(crate) fn write(&self, info: &ParticipantEntitiesInfo) -> Result<(), String> {
+        unsafe {
+            let buf = cdr::serialize::<_, _, CdrLe>(info, Infinite)
+                .map_err(|e| format!("Error serializing ParticipantEntitiesInfo: {}", e))?;
+
+            // create sertopic (Unfortunatelly cdds_ddsi_payload_create() takes *mut ddsi_sertopic. And keeping it in Self would make it not Send)
+            let cton = CString::new(ROS_DISCOVERY_INFO_TOPIC_NAME)
+                .unwrap()
+                .into_raw();
+            let ctyn = CString::new(ROS_DISCOVERY_INFO_TOPIC_TYPE)
+                .unwrap()
+                .into_raw();
+            let sertopic = cdds_create_blob_sertopic(self.participant, cton, ctyn, true);
+            drop(CString::from_raw(cton));
+            drop(CString::from_raw(ctyn));
+
+            // As per the Vec documentation (see https://doc.rust-lang.org/std/vec/struct.Vec.html#method.into_raw_parts)
+            // the only way to correctly releasing it is to create a vec using from_raw_parts
+            // and then have its destructor do the cleanup.
+            // Thus, while tempting to just pass the raw pointer to cyclone and then free it from C,
+            // that is not necessarily safe or guaranteed to be leak free.
+            // TODO replace when stable https://github.com/rust-lang/rust/issues/65816
+            let (ptr, len, capacity) = crate::vec_into_raw_parts(buf);
+            let fwdp =
+                cdds_ddsi_payload_create(sertopic, ddsi_serdata_kind_SDK_DATA, ptr, len as u64);
+            dds_writecdr(self.writer, fwdp as *mut ddsi_serdata);
+            drop(Vec::from_raw_parts(ptr, len, capacity));
+            cdds_sertopic_unref(sertopic);
+            Ok(())
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct NodesEntitieInfo {
+    pub node_namespace: String,
+    pub node_name: String,
+    #[serde(
+        serialize_with = "serialize_gids",
+        deserialize_with = "deserialize_gids"
+    )]
+    pub reader_gid_seq: Vec<String>,
+    #[serde(
+        serialize_with = "serialize_gids",
+        deserialize_with = "deserialize_gids"
+    )]
+    pub writer_gid_seq: Vec<String>,
+}
+
+impl std::fmt::Display for NodesEntitieInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Node {}{} : {} pub / {} sub",
+            self.node_namespace,
+            self.node_name,
+            self.reader_gid_seq.len(),
+            self.writer_gid_seq.len()
+        )?;
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct ParticipantEntitiesInfo {
+    #[serde(serialize_with = "serialize_gid", deserialize_with = "deserialize_gid")]
+    pub gid: String,
+    pub node_entities_info_seq: Vec<NodesEntitieInfo>,
+}
+
+impl std::fmt::Display for ParticipantEntitiesInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "participant {} : [", self.gid)?;
+        for i in &self.node_entities_info_seq {
+            write!(f, "({}), ", i)?;
+        }
+        write!(f, "]")?;
+        Ok(())
+    }
+}
+
+fn serialize_gid<S>(gid: &String, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut buf = hex::decode(gid).unwrap();
+    // Gid size in ROS messages in 24 bytes (The DDS gid is usually 16 bytes). Resize the buffer
+    buf.resize(24, 0);
+    serializer.serialize_bytes(&buf)
+}
+
+fn deserialize_gid<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let gid: [u8; 24] = Deserialize::deserialize(deserializer)?;
+    // NOTE: a DDS gid is 16 bytes only. ignore the last 8 bytes
+    Ok(hex::encode(&gid[..16]))
+}
+
+fn serialize_gids<S>(gids: &Vec<String>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut seq = serializer.serialize_seq(Some(gids.len()))?;
+    for s in gids {
+        let mut buf = hex::decode(s).unwrap();
+        // Gid size in ROS messages in 24 bytes (The DDS gid is usually 16 bytes). Resize the buffer
+        buf.resize(24, 0);
+        seq.serialize_element(buf.as_slice())?;
+    }
+    seq.end()
+}
+
+fn deserialize_gids<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let gids: Vec<[u8; 24]> = Deserialize::deserialize(deserializer)?;
+    // NOTE: a DDS gid is 16 bytes only. ignore the last 8 bytes
+    Ok(gids.iter().map(|gid| hex::encode(&gid[..16])).collect())
+}

--- a/zplugin-dds/src/ros_discovery.rs
+++ b/zplugin-dds/src/ros_discovery.rs
@@ -248,6 +248,32 @@ impl std::fmt::Display for ParticipantEntitiesInfo {
     }
 }
 
+impl ParticipantEntitiesInfo {
+    // Update with a new map of NodeEntitiesInfo, and cleanup the possibly NodeEntitiesInfo (no readers, no writers)
+    pub(crate) fn update_with(&mut self, nodes_entities: HashMap<String, NodeEntitiesInfo>) {
+        self.node_entities_info_seq.extend(nodes_entities);
+        self.cleanup();
+    }
+
+    pub(crate) fn remove_reader_gid(&mut self, reader_gid: &str) {
+        for node in self.node_entities_info_seq.values_mut() {
+            node.reader_gid_seq.retain(|gid| gid != reader_gid);
+        }
+    }
+
+    pub(crate) fn remove_writer_gid(&mut self, writer_gid: &str) {
+        for node in self.node_entities_info_seq.values_mut() {
+            node.writer_gid_seq.retain(|gid| gid != writer_gid);
+        }
+    }
+
+    // remove the empty NodeEntitiesInfo (no readers, no writers)
+    pub(crate) fn cleanup(&mut self) {
+        self.node_entities_info_seq
+            .retain(|_, node| !node.reader_gid_seq.is_empty() && !node.writer_gid_seq.is_empty());
+    }
+}
+
 fn serialize_gid<S>(gid: &str, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,

--- a/zplugin-dds/src/ros_discovery.rs
+++ b/zplugin-dds/src/ros_discovery.rs
@@ -188,7 +188,7 @@ impl RosDiscoveryInfoMgr {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub(crate) struct NodesEntitieInfo {
+pub(crate) struct NodeEntitiesInfo {
     pub node_namespace: String,
     pub node_name: String,
     #[serde(
@@ -203,7 +203,7 @@ pub(crate) struct NodesEntitieInfo {
     pub writer_gid_seq: Vec<String>,
 }
 
-impl std::fmt::Display for NodesEntitieInfo {
+impl std::fmt::Display for NodeEntitiesInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -221,13 +221,26 @@ impl std::fmt::Display for NodesEntitieInfo {
 pub(crate) struct ParticipantEntitiesInfo {
     #[serde(serialize_with = "serialize_gid", deserialize_with = "deserialize_gid")]
     pub gid: String,
-    pub node_entities_info_seq: Vec<NodesEntitieInfo>,
+    #[serde(
+        serialize_with = "serialize_node_entities_info_seq",
+        deserialize_with = "deserialize_node_entities_info_seq"
+    )]
+    pub node_entities_info_seq: HashMap<String, NodeEntitiesInfo>,
+}
+
+impl ParticipantEntitiesInfo {
+    pub(crate) fn new(gid: String) -> Self {
+        ParticipantEntitiesInfo {
+            gid,
+            node_entities_info_seq: HashMap::new(),
+        }
+    }
 }
 
 impl std::fmt::Display for ParticipantEntitiesInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "participant {} : [", self.gid)?;
-        for i in &self.node_entities_info_seq {
+        for i in self.node_entities_info_seq.values() {
             write!(f, "({}), ", i)?;
         }
         write!(f, "]")?;
@@ -278,4 +291,33 @@ where
     let gids: Vec<[u8; 24]> = Deserialize::deserialize(deserializer)?;
     // NOTE: a DDS gid is 16 bytes only. ignore the last 8 bytes
     Ok(gids.iter().map(|gid| hex::encode(&gid[..16])).collect())
+}
+
+fn serialize_node_entities_info_seq<S>(
+    entities: &HashMap<String, NodeEntitiesInfo>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut seq = serializer.serialize_seq(Some(entities.len()))?;
+    for entity in entities.values() {
+        seq.serialize_element(entity)?;
+    }
+    seq.end()
+}
+
+fn deserialize_node_entities_info_seq<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, NodeEntitiesInfo>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let mut entities: Vec<NodeEntitiesInfo> = Deserialize::deserialize(deserializer)?;
+    let mut map: HashMap<String, NodeEntitiesInfo> = HashMap::with_capacity(entities.len());
+    for entity in entities.drain(..) {
+        let key = format!("{}{}", entity.node_namespace, entity.node_name);
+        map.insert(key, entity);
+    }
+    Ok(map)
 }


### PR DESCRIPTION
This PR adds a **`--fwd-discovery`** option that activates a mode where:
 - on discovery of a local DDS reader or writer, the bridge forwards via zenoh this discovery information to the remote bridges
 - when receiving a discovery information via zenoh from a remote bridge, the bridge creates a similar _"serving"_ DDS reader or writer (same QoS), and route to/from zenoh for this entity
 - on reception of a DDS publication on `ros_discovery_info` topic, the bridge forwards it via zenoh to the remote bridges
 - when reception a `ros_discovery_info` data via zenoh, a bridge converts all the original GIDs to their equivalent GIDs for the created routes (i.e. the _"serving"_ DDS reader or writer for the route)
 - on un-discovery, or on the detection of the leaving or crash of a remote bridge, all the corresponding routes are cleaned-up, and an updated `ros_discovery_info` message is published to DDS

In a ROS2 system splitted in 2 (or more) hosts that are bridged via instances of this bridge using all this `--fwd-discovery`, this allow the discovery of the complete ROS graph on both hosts.