### PR TITLE
Add support of a configuration file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3070,7 +3070,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e3ebd2b8b822691711849b77bcd0f5c8d8e26c2f"
+source = "git+https://github.com/eclipse-zenoh/zenoh#6cd7aab4ca8e41d561efc853fd5dd334b7f7d64e"
 dependencies = [
  "async-global-executor",
  "async-rustls",
@@ -3123,6 +3123,8 @@ dependencies = [
  "async-std",
  "clap",
  "env_logger 0.9.0",
+ "lazy_static",
+ "log",
  "serde_json",
  "zenoh",
  "zenoh-plugin-rest",
@@ -3133,7 +3135,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e3ebd2b8b822691711849b77bcd0f5c8d8e26c2f"
+source = "git+https://github.com/eclipse-zenoh/zenoh#6cd7aab4ca8e41d561efc853fd5dd334b7f7d64e"
 dependencies = [
  "async-std",
  "bincode",
@@ -3150,7 +3152,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e3ebd2b8b822691711849b77bcd0f5c8d8e26c2f"
+source = "git+https://github.com/eclipse-zenoh/zenoh#6cd7aab4ca8e41d561efc853fd5dd334b7f7d64e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3162,7 +3164,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-rest"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e3ebd2b8b822691711849b77bcd0f5c8d8e26c2f"
+source = "git+https://github.com/eclipse-zenoh/zenoh#6cd7aab4ca8e41d561efc853fd5dd334b7f7d64e"
 dependencies = [
  "async-std",
  "base64 0.13.0",
@@ -3184,7 +3186,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e3ebd2b8b822691711849b77bcd0f5c8d8e26c2f"
+source = "git+https://github.com/eclipse-zenoh/zenoh#6cd7aab4ca8e41d561efc853fd5dd334b7f7d64e"
 dependencies = [
  "libloading",
  "log",
@@ -3196,7 +3198,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#e3ebd2b8b822691711849b77bcd0f5c8d8e26c2f"
+source = "git+https://github.com/eclipse-zenoh/zenoh#6cd7aab4ca8e41d561efc853fd5dd334b7f7d64e"
 dependencies = [
  "aes 0.7.5",
  "anyhow",

--- a/EXAMPLE_CONFIG.json5
+++ b/EXAMPLE_CONFIG.json5
@@ -1,0 +1,111 @@
+////
+//// This file is an example of configuration for zenoh-bridge-dds.
+//// The "dds" JSON5 object below can be used as such in the "plugins" part
+//// of a config file for the zenoh router (zenohd).
+////
+{
+  plugins: {
+    ////
+    //// DDS related configuration
+    //// All settings are optional - uncomment the ones you want to set
+    ////
+    dds: {
+      ////
+      //// scope: A string added as prefix to all routed DDS topics when mapped to a zenoh resource.
+      ////        This should be used to avoid conflicts when several distinct DDS systems using
+      ////        the same topics names are routed via zenoh.
+      ////
+      // scope: "/robot-1",
+
+      ////
+      //// domain: The DDS Domain ID (if using with ROS this should be the same as ROS_DOMAIN_ID).
+      ////
+      // domain: 1,
+
+      ////
+      //// group_member_id: A custom identifier for the bridge, that will be used in group management
+      ////                  (if not specified, the zenoh UUID is used).
+      ////
+      // group_member_id: "robot-1",
+
+      ////
+      //// group_lease: The lease duration (in seconds) used in group management for all DDS plugins.
+      ////
+      // group_lease: 2.5,
+
+      ////
+      //// allow: A regular expression matching the set of 'partition/topic-name' that should be bridged. 
+      ////        By default, all partitions and topic are allowed.
+      ////        Examples of expressions: ".*/TopicA", "Partition-?/.*", "cmd_vel|rosout"...'"#
+      ////
+      // allow: "cmd_vel|rosout",
+
+      ////
+      //// max_frequencies: Specifies a list of maximum frequency of data routing over zenoh for a set of topics.
+      ////                  The strings must have the format "<regex>=<float>":
+      ////                  - "regex" is a regular expression matching the set of "partition/topic-name"
+      ////                    (same syntax than --allow option) for which the data (per DDS instance) must be
+      ////                    routed at no higher rate than the specified max frequency.
+      ////                  - "float" is the maximum frequency in Hertz; 
+      ////                    if publication rate is higher, downsampling will occur when routing.
+      //max_frequencies: ["diagnostic.*=10", "rosout=5"],
+
+      ////
+      //// generalise_subs: A list of key expression to use for generalising subscriptions.
+      ////
+      // generalise_subs: ["SUB1", "SUB2"],
+
+      ////
+      //// generalise_subs: A list of key expression to use for generalising publications.
+      ////
+      // generalise_subs: ["PUB1", "PUB2"],
+
+
+      ////
+      //// forward_discovery: When true, rather than creating a local route when discovering a local DDS entity,
+      ////                    this discovery info is forwarded to the remote plugins/bridges. 
+      ////                   Those will create the routes, including a replica of the discovered entity.
+      ////
+      // forward_discovery: true,
+    },
+
+    ////
+    //// REST API configuration (active only if this part is defined)
+    ////
+    // rest: {
+    //   ////
+    //   //// The HTTP port number (for all network interfaces).
+    //   //// You can bind on a specific interface setting a "<local_ip>:<port>" string.
+    //   ////
+    //   http_port: 8000,
+    // },
+  },
+
+  ////
+  //// zenoh related configuration (see zenoh documentation for more details)
+  ////
+
+  ////
+  //// id: The identifier (as hex-string) that zenoh-bridge-dds must use. If not set, a random UUIDv4 will be used.
+  //// WARNING: this id must be unique in your zenoh network.
+  // id: "A00001",
+
+  ////
+  //// mode: The bridge's mode (peer or client)
+  ////
+  //mode: "client",
+
+  ////
+  //// peers: Which locators to connect to, proto may be one of tcp|udp|quic|tls|unixsock-stream.
+  ////
+  peers: [
+    // "<proto>/<ip>:<port>"
+  ],
+
+  ////
+  //// listeners: Which locators to listen on. These are typically bound to local IPs or 0.0.0.0
+  ////
+  listeners: [
+    // "<proto>/<ip>:<port>"
+  ],
+}

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ cd zenoh-plugin-dds
 ```
 
 You can then choose between building the zenoh bridge for DDS:
-- as a dynamically loaded plugin:
+- as a plugin library that can be dynamically loaded by the zenoh router (`zenohd`):
 ```bash
 $ cargo build --release -p zplugin-dds
 ```
@@ -167,10 +167,15 @@ As you understood, using the zenoh bridge, each ROS2 publications and subscripti
 
 See in details how to achieve that in [this blog](https://zenoh.io/blog/2021-04-28-ros2-integration/).
 
-## All zenoh-bridge-dds command line arguments
+## Configuration
 
-`zenoh-bridge-dds` accepts the following arguments:
+`zenoh-bridge-dds` can be configured via a JSON5 file passed via the `-c`argument. You can see a commented example of such configuration file: [`EXAMPLE_CONFIG.json5`](EXAMPLE_CONFIG.json5).
+
+The `"dds"` part of this configuration file can also be used in the configuration file for the zenoh router (within its `"plugins"` part). The router will automatically try to load the plugin library (`zplugin_dds`) at startup and apply its configuration.
+
+`zenoh-bridge-dds` also accepts the following arguments. If set, each argument will override the similar setting from the configuration file:
  * zenoh-related arguments:
+   - **`-c, --config <FILE>`** : a config file
    - **`-m, --mode <MODE>`** : The zenoh session mode. Default: `peer` Possible values: `peer` or `client`.  
       See [zenoh documentation](https://zenoh.io/docs/getting-started/key-concepts/#deployment-units) for more details.
    - **`-l, --listener <LOCATOR>`** : The locators the bridge will listen on for zenoh protocol. Can be specified multiple times. Example of locator: `tcp/localhost:7447`.

--- a/zenoh-bridge-dds/Cargo.toml
+++ b/zenoh-bridge-dds/Cargo.toml
@@ -29,7 +29,9 @@ description = "Zenoh plugin for ROS2 and DDS in general"
 
 [dependencies]
 clap = "2.33"
+log = "0.4"
 env_logger = "0.9.0"
+lazy_static = "1.4.0"
 serde_json = "1.0.71"
 zenoh = { git = "https://github.com/eclipse-zenoh/zenoh" }
 zenoh-plugin-rest = { git = "https://github.com/eclipse-zenoh/zenoh", default-features = false }

--- a/zplugin-dds/src/config.rs
+++ b/zplugin-dds/src/config.rs
@@ -15,10 +15,10 @@ use regex::Regex;
 use serde::{de, Deserialize, Deserializer};
 use std::time::Duration;
 
-const DEFAULT_SCOPE: &str = "";
-const DEFAULT_DOMAIN: u32 = 0;
-const DEFAULT_GROUP_LEASE_SEC: f64 = 3.0;
-const DEFAULT_FORWARD_DISCOVERY: bool = false;
+pub const DEFAULT_SCOPE: &str = "";
+pub const DEFAULT_DOMAIN: u32 = 0;
+pub const DEFAULT_GROUP_LEASE_SEC: f64 = 3.0;
+pub const DEFAULT_FORWARD_DISCOVERY: bool = false;
 
 #[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
@@ -39,9 +39,9 @@ pub struct Config {
     #[serde(default, deserialize_with = "deserialize_max_frequencies")]
     pub max_frequencies: Vec<(Regex, f32)>,
     #[serde(default)]
-    pub join_subscriptions: Vec<String>,
+    pub generalise_subs: Vec<String>,
     #[serde(default)]
-    pub join_publications: Vec<String>,
+    pub generalise_pubs: Vec<String>,
     #[serde(default = "default_forward_discovery")]
     pub forward_discovery: bool,
     #[serde(default)]

--- a/zplugin-dds/src/lib.rs
+++ b/zplugin-dds/src/lib.rs
@@ -44,7 +44,7 @@ use zenoh_ext::{PublicationCache, QueryingSubscriber, SessionExt};
 use zenoh_util::collections::{Timed, TimedEvent, Timer};
 use zenoh_util::{bail, zerror};
 
-mod config;
+pub mod config;
 mod dds_mgt;
 mod qos;
 mod ros_discovery;
@@ -64,9 +64,6 @@ lazy_static::lazy_static!(
 );
 
 const GROUP_NAME: &str = "zenoh-plugin-dds";
-lazy_static::lazy_static!(
-    pub static ref DDS_DOMAIN_DEFAULT_STR: String = DDS_DOMAIN_DEFAULT.to_string();
-);
 const PUB_CACHE_QUERY_PREFIX: &str = "/@dds_pub_cache";
 
 const ROS_DISCOVERY_INFO_POLL_INTERVAL_MS: u64 = 500;
@@ -139,8 +136,8 @@ pub async fn run(runtime: Runtime, config: Config) {
         Session::init(
             runtime,
             false,
-            config.join_subscriptions.clone(),
-            config.join_publications.clone(),
+            config.generalise_subs.clone(),
+            config.generalise_pubs.clone(),
         )
         .await,
     );


### PR DESCRIPTION
 - Adds a `-c, --config <file>` option to `zenoh-bridge-dds`
 - Documents this configuration file
 - Update the behaviour of the command line arguments to override their equivalent in the config file