### PR TITLE
Add 'reliable_routes_blocking' conf and manage CongestionControl (#66)

### DIFF
--- a/EXAMPLE_CONFIG.json5
+++ b/EXAMPLE_CONFIG.json5
@@ -60,13 +60,22 @@
       ////
       // generalise_subs: ["PUB1", "PUB2"],
 
-
       ////
       //// forward_discovery: When true, rather than creating a local route when discovering a local DDS entity,
-      ////                    this discovery info is forwarded to the remote plugins/bridges. 
-      ////                   Those will create the routes, including a replica of the discovered entity.
+      ////                    this discovery info is forwarded to the remote plugins/bridges.
+      ////                    Those will create the routes, including a replica of the discovered entity.
       ////
-      // forward_discovery: true,
+      // forward_discovery: false,
+
+      ////
+      //// reliable_routes_blocking: When true, the publications from a RELIABLE DDS Writer will be
+      ////                           routed to zenoh using the CongestionControl::Block option.
+      ////                           Meaning the routing will be blocked in case of network congestion,
+      ////                           blocking the DDS Reader and the RELIABLE DDS Writer in return.
+      ////                           When false (or for BERST_EFFORT DDS Writers), CongestionControl::Drop
+      ////                           is used, meaning the route might drop some data in case of congestion.
+      ////
+      // reliable_routes_blocking: true,
     },
 
     ////

--- a/zplugin-dds/src/config.rs
+++ b/zplugin-dds/src/config.rs
@@ -19,6 +19,7 @@ pub const DEFAULT_SCOPE: &str = "";
 pub const DEFAULT_DOMAIN: u32 = 0;
 pub const DEFAULT_GROUP_LEASE_SEC: f64 = 3.0;
 pub const DEFAULT_FORWARD_DISCOVERY: bool = false;
+pub const DEFAULT_RELIABLE_ROUTES_BLOCKING: bool = true;
 
 #[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
@@ -44,6 +45,8 @@ pub struct Config {
     pub generalise_pubs: Vec<String>,
     #[serde(default = "default_forward_discovery")]
     pub forward_discovery: bool,
+    #[serde(default = "default_reliable_routes_blocking")]
+    pub reliable_routes_blocking: bool,
     #[serde(default)]
     __required__: bool,
     #[serde(default, deserialize_with = "deserialize_paths")]
@@ -140,4 +143,8 @@ where
 
 fn default_forward_discovery() -> bool {
     DEFAULT_FORWARD_DISCOVERY
+}
+
+fn default_reliable_routes_blocking() -> bool {
+    DEFAULT_RELIABLE_ROUTES_BLOCKING
 }


### PR DESCRIPTION
This PR fixes #66, adding a `reliable_routes_blocking` boolean configuration:
When true, the publications from a RELIABLE DDS Writer will be routed to zenoh using the CongestionControl::Block option. Meaning the routing will be blocked in case of network congestion, blocking the DDS Reader and the RELIABLE DDS Writer in return.
When false (or for BERST_EFFORT DDS Writers), CongestionControl::Drop is used, meaning the route might drop some data in case of congestion.