### PR TITLE
Fix parsing of fwd discovery path

### DIFF
--- a/zplugin-dds/src/lib.rs
+++ b/zplugin-dds/src/lib.rs
@@ -1485,7 +1485,7 @@ impl<'a> DdsPluginRuntime<'a> {
             // publication on a key expression matching the fwd_path: ignore it
             return None;
         }
-        let remote_uuid = if let Some(uuid) = split_it.nth(2) {
+        let remote_uuid = if let Some(uuid) = split_it.next() {
             uuid
         } else {
             error!(


### PR DESCRIPTION
Fix a bug that was introduced in 5941e9bf76 : 
in forward discovery mode, the parsing of paths used to forward the discovery information was incorrect at reception.
This was leading to wrong admin paths in route's `remote_routed_writers`/`remote_routed_readers` lists, and consequently to the inability to correctly cleanup the routes and entities when a remote bridge leaves.