### PR TITLE
Revert Locality and mark local_routing as unstable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3152,7 +3152,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#2a3c58677a99363a41ae9c24af817413cf048703"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
 dependencies = [
  "async-global-executor",
  "async-std",
@@ -3213,7 +3213,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#2a3c58677a99363a41ae9c24af817413cf048703"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
 dependencies = [
  "async-std",
  "bincode",
@@ -3228,7 +3228,7 @@ dependencies = [
 [[package]]
 name = "zenoh-cfg-properties"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#2a3c58677a99363a41ae9c24af817413cf048703"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
 dependencies = [
  "zenoh-core",
  "zenoh-macros",
@@ -3237,7 +3237,7 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#2a3c58677a99363a41ae9c24af817413cf048703"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3250,7 +3250,7 @@ dependencies = [
 [[package]]
 name = "zenoh-config"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#2a3c58677a99363a41ae9c24af817413cf048703"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
 dependencies = [
  "flume",
  "json5",
@@ -3268,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#2a3c58677a99363a41ae9c24af817413cf048703"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -3277,7 +3277,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#2a3c58677a99363a41ae9c24af817413cf048703"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
 dependencies = [
  "aes 0.8.1",
  "hmac 0.12.1",
@@ -3290,7 +3290,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#2a3c58677a99363a41ae9c24af817413cf048703"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
 dependencies = [
  "async-std",
  "bincode",
@@ -3308,7 +3308,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#2a3c58677a99363a41ae9c24af817413cf048703"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3327,7 +3327,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#2a3c58677a99363a41ae9c24af817413cf048703"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3342,7 +3342,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#2a3c58677a99363a41ae9c24af817413cf048703"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3365,7 +3365,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#2a3c58677a99363a41ae9c24af817413cf048703"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3380,7 +3380,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#2a3c58677a99363a41ae9c24af817413cf048703"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -3399,7 +3399,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#2a3c58677a99363a41ae9c24af817413cf048703"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3416,7 +3416,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#2a3c58677a99363a41ae9c24af817413cf048703"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3433,7 +3433,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#2a3c58677a99363a41ae9c24af817413cf048703"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3445,7 +3445,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-rest"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#2a3c58677a99363a41ae9c24af817413cf048703"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
 dependencies = [
  "anyhow",
  "async-std",
@@ -3470,7 +3470,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#2a3c58677a99363a41ae9c24af817413cf048703"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
 dependencies = [
  "libloading",
  "log",
@@ -3483,7 +3483,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#2a3c58677a99363a41ae9c24af817413cf048703"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
 dependencies = [
  "log",
  "uhlc",
@@ -3495,7 +3495,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol-core"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#2a3c58677a99363a41ae9c24af817413cf048703"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
 dependencies = [
  "hex",
  "itertools",
@@ -3510,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#2a3c58677a99363a41ae9c24af817413cf048703"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
 dependencies = [
  "async-std",
  "event-listener",
@@ -3523,7 +3523,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#2a3c58677a99363a41ae9c24af817413cf048703"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
 dependencies = [
  "async-executor",
  "async-global-executor",
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#2a3c58677a99363a41ae9c24af817413cf048703"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
 dependencies = [
  "async-std",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "d8bf247779e67a9082a4790b45e71ac7cfd1321331a5c856a74a9faebdab78d0"
 dependencies = [
  "either",
 ]
@@ -2681,9 +2681,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.0"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89797afd69d206ccd11fb0ea560a44bbb87731d020670e79416d442919257d42"
+checksum = "0020c875007ad96677dcc890298f4b942882c5d4eb7cc8f439fc3bf813dc9c95"
 dependencies = [
  "autocfg",
  "libc",
@@ -3152,7 +3152,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-global-executor",
  "async-std",
@@ -3213,7 +3213,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-std",
  "bincode",
@@ -3228,7 +3228,7 @@ dependencies = [
 [[package]]
 name = "zenoh-cfg-properties"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "zenoh-core",
  "zenoh-macros",
@@ -3237,7 +3237,7 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3250,7 +3250,7 @@ dependencies = [
 [[package]]
 name = "zenoh-config"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "flume",
  "json5",
@@ -3268,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -3277,7 +3277,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "aes 0.8.1",
  "hmac 0.12.1",
@@ -3290,7 +3290,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-std",
  "bincode",
@@ -3308,7 +3308,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3327,7 +3327,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3342,7 +3342,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3365,7 +3365,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3380,7 +3380,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -3399,7 +3399,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3416,7 +3416,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3433,7 +3433,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3445,7 +3445,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-rest"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "anyhow",
  "async-std",
@@ -3470,7 +3470,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "libloading",
  "log",
@@ -3483,7 +3483,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "log",
  "uhlc",
@@ -3495,7 +3495,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol-core"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "hex",
  "itertools",
@@ -3510,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-std",
  "event-listener",
@@ -3523,7 +3523,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-executor",
  "async-global-executor",
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#7149886ca65c9e375c8110d0570820a418d175da"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-std",
  "clap",

--- a/zenoh-bridge-dds/Cargo.toml
+++ b/zenoh-bridge-dds/Cargo.toml
@@ -33,7 +33,7 @@ log = "0.4"
 env_logger = "0.9.0"
 lazy_static = "1.4.0"
 serde_json = "1.0.71"
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "local-routing" }
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "local-routing", features = ["unstable"] }
 zenoh-plugin-rest = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "local-routing", default-features = false }
 zenoh-plugin-trait = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "local-routing", default-features = false }
 zplugin-dds = { path = "../zplugin-dds", default-features = false }

--- a/zenoh-bridge-dds/Cargo.toml
+++ b/zenoh-bridge-dds/Cargo.toml
@@ -33,9 +33,9 @@ log = "0.4"
 env_logger = "0.9.0"
 lazy_static = "1.4.0"
 serde_json = "1.0.71"
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh", branch ="api-changes" }
-zenoh-plugin-rest = { git = "https://github.com/eclipse-zenoh/zenoh", branch ="api-changes", default-features = false }
-zenoh-plugin-trait = { git = "https://github.com/eclipse-zenoh/zenoh", branch ="api-changes", default-features = false }
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "local-routing" }
+zenoh-plugin-rest = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "local-routing", default-features = false }
+zenoh-plugin-trait = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "local-routing", default-features = false }
 zplugin-dds = { path = "../zplugin-dds", default-features = false }
 
 [dependencies.async-std]

--- a/zenoh-bridge-dds/src/main.rs
+++ b/zenoh-bridge-dds/src/main.rs
@@ -193,6 +193,7 @@ r#"-f, --fwd-discovery   'When set, rather than creating a local route when disc
 
 #[async_std::main]
 async fn main() {
+    use zenoh_plugin_trait::Plugin;
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("z=info")).init();
     log::info!("zenoh-bridge-dds {}", *zplugin_dds::LONG_VERSION);
 
@@ -209,7 +210,6 @@ async fn main() {
     }
 
     // start DDS plugin
-    use zenoh_plugin_trait::Plugin;
     zplugin_dds::DDSPlugin::start("dds", &runtime).unwrap();
     async_std::task::block_on(async_std::future::pending::<()>());
 }

--- a/zplugin-dds/Cargo.toml
+++ b/zplugin-dds/Cargo.toml
@@ -36,7 +36,7 @@ no_mangle = ["zenoh-plugin-trait/no_mangle"]
 default = ["no_mangle"]
 
 [dependencies]
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "local-routing" }
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "local-routing", features = ["unstable"] }
 zenoh-ext = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "local-routing" }
 zenoh-core = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "local-routing" }
 zenoh-collections = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "local-routing" }

--- a/zplugin-dds/Cargo.toml
+++ b/zplugin-dds/Cargo.toml
@@ -36,11 +36,11 @@ no_mangle = ["zenoh-plugin-trait/no_mangle"]
 default = ["no_mangle"]
 
 [dependencies]
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh", branch ="api-changes" }
-zenoh-ext = { git = "https://github.com/eclipse-zenoh/zenoh", branch ="api-changes" }
-zenoh-core = { git = "https://github.com/eclipse-zenoh/zenoh", branch ="api-changes" }
-zenoh-collections = { git = "https://github.com/eclipse-zenoh/zenoh", branch ="api-changes" }
-zenoh-plugin-trait = { git = "https://github.com/eclipse-zenoh/zenoh", branch ="api-changes", default-features = false }
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "local-routing" }
+zenoh-ext = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "local-routing" }
+zenoh-core = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "local-routing" }
+zenoh-collections = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "local-routing" }
+zenoh-plugin-trait = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "local-routing", default-features = false }
 cyclors = "0.1.4"
 log = "0.4.14"
 async-trait = "0.1.42"

--- a/zplugin-dds/src/lib.rs
+++ b/zplugin-dds/src/lib.rs
@@ -138,21 +138,16 @@ pub async fn run(runtime: Runtime, config: Config) {
     debug!("DDS plugin {:?}", config);
 
     // open zenoh-net Session (with local routing disabled to avoid loops)
-
-    let zsession = match zenoh::init(runtime)
-        .queriables_allowed_origin(Locality::Remote)
-        .subscribers_allowed_origin(Locality::Remote)
-        .aggregated_subscribers(config.generalise_subs.clone())
-        .aggregated_publishers(config.generalise_pubs.clone())
+    let zsession = Arc::new(
+        Session::init(
+            runtime,
+            false,
+            config.generalise_subs.clone(),
+            config.generalise_pubs.clone(),
+        )
         .res()
-        .await
-    {
-        Ok(session) => Arc::new(session),
-        Err(e) => {
-            log::error!("Unable to init zenoh session for DDS plugin : {:?}", e);
-            return;
-        }
-    };
+        .await,
+    );
 
     // create group member using the group_member_id if configured, or the Session ID otherwise
     let member_id = match config.group_member_id {


### PR DESCRIPTION
Sister PR: https://github.com/eclipse-zenoh/zenoh/pull/320.

This PR is marked as draft since the zenoh branch in `Cargo.toml` should point to `api-changes` instead of `local-routing`.
Once the sister PR is merged, the `api-changes` branch will be configured in `Cargo.toml` and this PR will be ready to be merged.