### PR TITLE
Add support of ROS_DOMAIN_ID and ROS_LOCALHOST_ONLY env variables

### DIFF
--- a/EXAMPLE_CONFIG.json5
+++ b/EXAMPLE_CONFIG.json5
@@ -18,9 +18,15 @@
       // scope: "robot-1",
 
       ////
-      //// domain: The DDS Domain ID (if using with ROS this should be the same as ROS_DOMAIN_ID).
+      //// domain: The DDS Domain ID. By default set to 0, or to "$ROS_DOMAIN_ID" is this environment variable is defined.
       ////
-      // domain: 1,
+      // domain: 0,
+
+      ////
+      //// localhost_only: If set to true, the DDS discovery and traffic will occur only on the localhost interface (127.0.0.1).
+      ////                 By default set to false, unless the "ROS_LOCALHOST_ONLY=1" environment variable is defined.
+      ////
+      // localhost_only: true,
 
       ////
       //// group_member_id: A custom identifier for the bridge, that will be used in group management

--- a/README.md
+++ b/README.md
@@ -194,7 +194,9 @@ The `"dds"` part of this configuration file can also be used in the configuratio
    - **`--rest-plugin`** : activate the [zenoh REST API](https://zenoh.io/docs/apis/apis/#rest-api), available by default on port 8000.
    - **`--rest-http-port <rest-http-port>`** : set the REST API http port (default: 8000)
  * DDS-related arguments:
-   - **`-d, --domain <ID>`** : The DDS Domain ID (if using with ROS this should be the same as `ROS_DOMAIN_ID`)
+   - **`-d, --domain <ID>`** : The DDS Domain ID. By default set to `0`, or to `"$ROS_DOMAIN_ID"` is this environment variable is defined.
+   - **`dds-localhost-only`** : If set, the DDS discovery and traffic will occur only on the localhost interface (127.0.0.1).
+     By default set to false, unless the "ROS_LOCALHOST_ONLY=1" environment variable is defined.
    - **`-f, --fwd-discovery`** : When set, rather than creating a local route when discovering a local DDS entity, this discovery info is forwarded to the remote plugins/bridges. Those will create the routes, including a replica of the discovered entity. More details [here](#full-support-of-ros-graph-and-topic-lists-via-the-forward-discovery-mode)
    - **`-s, --scope <String>`** : A string used as prefix to scope DDS traffic when mapped to zenoh keys.
    - **`-a, --allow <String>`** :  A regular expression matching the set of 'partition/topic-name' that must be routed via zenoh.

--- a/zenoh-bridge-dds/src/main.rs
+++ b/zenoh-bridge-dds/src/main.rs
@@ -90,12 +90,13 @@ r#"--rest-http-port=[PORT | IP:PORT] \
 r#"-s, --scope=[String]   'A string added as prefix to all routed DDS topics when mapped to a zenoh resource. This should be used to avoid conflicts when several distinct DDS systems using the same topics names are routed via zenoh'"#
         ))
         .arg(Arg::from_usage(
-r#"-d, --domain=[ID]   'The DDS Domain ID. If not set this defaults to the value of "ROS_DOMAIN_ID" environment variable or to 0 if unset.'"#)
+r#"-d, --domain=[ID]   'The DDS Domain ID. The default value is "$ROS_DOMAIN_ID" if defined, or "0" otherwise.'"#)
             .default_value(&*DEFAULT_DOMAIN_STR)
         )
         .arg(Arg::from_usage(
 r#"--dds-localhost-only \
-'Configure CycloneDDS to use only the localhost interface. If the "ROS_LOCALHOST_ONLY" environement variable is set to "1", this option is active by default.'"#
+'Configure CycloneDDS to use only the localhost interface. If not set, CycloneDDS will pick the interface defined in "$CYCLONEDDS_URI" configuration, or automatically choose one.
+This option is not active by default, unless the "ROS_LOCALHOST_ONLY" environement variable is set to "1".'"#
         ))
         .arg(Arg::from_usage(
 r#"--group-member-id=[ID]   'A custom identifier for the bridge, that will be used in group management (if not specified, the zenoh UUID is used).'"#

--- a/zplugin-dds/src/config.rs
+++ b/zplugin-dds/src/config.rs
@@ -56,7 +56,11 @@ pub struct Config {
 }
 
 fn default_domain() -> u32 {
-    DEFAULT_DOMAIN
+    if let Ok(s) = env::var("ROS_DOMAIN_ID") {
+        s.parse::<u32>().unwrap_or(DEFAULT_DOMAIN)
+    } else {
+        DEFAULT_DOMAIN
+    }
 }
 
 fn default_group_lease() -> Duration {

--- a/zplugin-dds/src/config.rs
+++ b/zplugin-dds/src/config.rs
@@ -13,6 +13,7 @@
 //
 use regex::Regex;
 use serde::{de, Deserialize, Deserializer};
+use std::env;
 use std::time::Duration;
 use zenoh::prelude::*;
 
@@ -20,6 +21,7 @@ pub const DEFAULT_DOMAIN: u32 = 0;
 pub const DEFAULT_GROUP_LEASE_SEC: f64 = 3.0;
 pub const DEFAULT_FORWARD_DISCOVERY: bool = false;
 pub const DEFAULT_RELIABLE_ROUTES_BLOCKING: bool = true;
+pub const DEFAULT_DDS_LOCALHOST_ONLY: bool = false;
 
 #[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
@@ -49,6 +51,8 @@ pub struct Config {
     pub forward_discovery: bool,
     #[serde(default = "default_reliable_routes_blocking")]
     pub reliable_routes_blocking: bool,
+    #[serde(default = "default_localhost_only")]
+    pub localhost_only: bool,
     #[serde(default)]
     __required__: bool,
     #[serde(default, deserialize_with = "deserialize_paths")]
@@ -149,4 +153,8 @@ fn default_forward_discovery() -> bool {
 
 fn default_reliable_routes_blocking() -> bool {
     DEFAULT_RELIABLE_ROUTES_BLOCKING
+}
+
+fn default_localhost_only() -> bool {
+    env::var("ROS_LOCALHOST_ONLY").as_deref() == Ok("1")
 }


### PR DESCRIPTION
This PR brings the following changes to the configuration:
 * **`domain`** (`-d, --domain` for zenoh-bridge-dds): if not specified, the default value will be `$ROS_DOMAIN_ID` environment variable if defined, or `0` otherwise
 * NEW **localhost_only** (`--dds-localhost-only`): if set to `true`, CycloneDDS is configured to use only the localhost interface (127.0.0.1). This option is added to the `$CYCLONEDDS_URI` configuration if defined. The default value is `false`, unless the "ROS_LOCALHOST_ONLY=1" environment variable is defined.

In both cases, the JSON5 configuration (or the command line options) always prevails on the environment variables.