### PR TITLE
Release Action: add build for aarch64-apple-darwin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,7 @@ jobs:
         job:
           - { target: x86_64-unknown-linux-gnu, arch: amd64, os: ubuntu-20.04 }
           - { target: x86_64-apple-darwin, arch: darwin, os: macos-latest }
+          - { target: aarch64-apple-darwin, arch: darwin, os: macos-latest }
           - {
               target: x86_64-unknown-linux-musl,
               arch: amd64,


### PR DESCRIPTION
Add a build for ARM64-based MacOS.