### PR TITLE
Add a watchdog of tasks scheduling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-liveliness-monitor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "902174b1c1b8b63ed4d522448fd639c45ab86d78d75575b39e3946d465183c72"
+
+[[package]]
 name = "async-lock"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3205,6 +3211,7 @@ dependencies = [
 name = "zenoh-bridge-dds"
 version = "0.6.0-beta.1"
 dependencies = [
+ "async-liveliness-monitor",
  "async-std",
  "clap",
  "env_logger",

--- a/zenoh-bridge-dds/Cargo.toml
+++ b/zenoh-bridge-dds/Cargo.toml
@@ -33,6 +33,7 @@ env_logger = "0.9.0"
 lazy_static = "1.4.0"
 log = "0.4"
 serde_json = "1.0.71"
+async-liveliness-monitor = "0.1.1"
 zenoh = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master", features = ["unstable"] }
 zenoh-plugin-rest = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master", default-features = false }
 zenoh-plugin-trait = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master", default-features = false }

--- a/zenoh-bridge-dds/src/main.rs
+++ b/zenoh-bridge-dds/src/main.rs
@@ -249,12 +249,19 @@ fn run_watchdog(period: f32) {
     // 2nd threshold of duration since last report => debug warn if exceeded
     let report_threshold_2 = Duration::from_millis(100);
 
-    assert!(sleep_time > report_threshold_2, "Watchdog period must be greater than {} seconds", report_threshold_2.as_secs_f32());
+    assert!(
+        sleep_time > report_threshold_2,
+        "Watchdog period must be greater than {} seconds",
+        report_threshold_2.as_secs_f32()
+    );
 
     // Start a Liveliness Monitor thread for async_std Runtime
     let (_task, monitor) = LivelinessMonitor::start(async_std::task::spawn);
     std::thread::spawn(move || {
-        log::debug!("Watchdog started with period {} sec", sleep_time.as_secs_f32());
+        log::debug!(
+            "Watchdog started with period {} sec",
+            sleep_time.as_secs_f32()
+        );
         loop {
             let before = SystemTime::now();
             std::thread::sleep(sleep_time);
@@ -262,7 +269,10 @@ fn run_watchdog(period: f32) {
 
             // Monitor watchdog thread itself
             if elapsed > sleep_time + max_sleep_delta {
-                log::warn!("Watchdog thread slept more than configured: {} seconds", elapsed.as_secs_f32());
+                log::warn!(
+                    "Watchdog thread slept more than configured: {} seconds",
+                    elapsed.as_secs_f32()
+                );
             }
             // check last LivelinessMonitor's report
             let report = monitor.latest_report();

--- a/zenoh-bridge-dds/src/main.rs
+++ b/zenoh-bridge-dds/src/main.rs
@@ -1,3 +1,4 @@
+use async_liveliness_monitor::LivelinessMonitor;
 //
 // Copyright (c) 2022 ZettaScale Technology
 //
@@ -13,6 +14,7 @@
 //
 use clap::{App, Arg};
 use std::str::FromStr;
+use std::time::{Duration, SystemTime};
 use zenoh::config::{Config, ModeDependentValue};
 use zenoh::prelude::*;
 
@@ -39,7 +41,7 @@ macro_rules! insert_json5 {
     };
 }
 
-fn parse_args() -> Config {
+fn parse_args() -> (Config, Option<f32>) {
     let app = App::new("zenoh bridge for DDS")
         .version(zplugin_dds::GIT_VERSION)
         .long_version(zplugin_dds::LONG_VERSION.as_str())
@@ -131,7 +133,10 @@ r#"-w, --generalise-pub=[String]...   'A list of key expression to use for gener
         .arg(Arg::from_usage(
 r#"-f, --fwd-discovery   'When set, rather than creating a local route when discovering a local DDS entity, this discovery info is forwarded to the remote plugins/bridges. Those will create the routes, including a replica of the discovered entity.'"#
             ).alias("forward-discovery")
-        );
+        )
+        .arg(Arg::from_usage(
+r#"--watchdog=[PERIOD]   'Experimental!! Run a watchdog thread that monitors the bridge's async executor and reports as error log any stalled status during the specified period (default: 1.0 second)'"#
+        ).default_missing_value("1.0"));
     let args = app.get_matches();
 
     // load config file at first
@@ -176,7 +181,6 @@ r#"-f, --fwd-discovery   'When set, rather than creating a local route when disc
             .insert_json5("plugins/rest/http_port", &format!(r#""{}""#, port))
             .unwrap();
     }
-
     // Always add timestamps to publications (required for PublicationCache used in case of TRANSIENT_LOCAL topics)
     config
         .timestamping
@@ -199,7 +203,14 @@ r#"-f, --fwd-discovery   'When set, rather than creating a local route when disc
             .insert_json5("plugins/dds/forward_discovery", "true")
             .unwrap();
     }
-    config
+
+    let watchdog_period = if args.is_present("watchdog") {
+        args.value_of("watchdog").map(|s| s.parse::<f32>().unwrap())
+    } else {
+        None
+    };
+
+    (config, watchdog_period)
 }
 
 #[async_std::main]
@@ -207,8 +218,12 @@ async fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("z=info")).init();
     log::info!("zenoh-bridge-dds {}", *zplugin_dds::LONG_VERSION);
 
-    let config = parse_args();
+    let (config, watchdog_period) = parse_args();
     let rest_plugin = config.plugin("rest").is_some();
+
+    if let Some(period) = watchdog_period {
+        run_watchdog(period);
+    }
 
     // create a zenoh Runtime (to share with plugins)
     let runtime = zenoh::runtime::Runtime::new(config).await.unwrap();
@@ -223,4 +238,43 @@ async fn main() {
     use zenoh_plugin_trait::Plugin;
     zplugin_dds::DDSPlugin::start("dds", &runtime).unwrap();
     async_std::task::block_on(async_std::future::pending::<()>());
+}
+
+fn run_watchdog(period: f32) {
+    let sleep_time = Duration::from_secs_f32(period);
+    // max delta accepted for watchdog thread sleep period
+    let max_sleep_delta = Duration::from_millis(50);
+    // 1st threshold of duration since last report => debug info if exceeded
+    let report_threshold_1 = Duration::from_millis(10);
+    // 2nd threshold of duration since last report => debug warn if exceeded
+    let report_threshold_2 = Duration::from_millis(100);
+
+    assert!(sleep_time > report_threshold_2, "Watchdog period must be greater than {} seconds", report_threshold_2.as_secs_f32());
+
+    // Start a Liveliness Monitor thread for async_std Runtime
+    let (_task, monitor) = LivelinessMonitor::start(async_std::task::spawn);
+    std::thread::spawn(move || {
+        log::debug!("Watchdog started with period {} sec", sleep_time.as_secs_f32());
+        loop {
+            let before = SystemTime::now();
+            std::thread::sleep(sleep_time);
+            let elapsed = SystemTime::now().duration_since(before).unwrap();
+
+            // Monitor watchdog thread itself
+            if elapsed > sleep_time + max_sleep_delta {
+                log::warn!("Watchdog thread slept more than configured: {} seconds", elapsed.as_secs_f32());
+            }
+            // check last LivelinessMonitor's report
+            let report = monitor.latest_report();
+            if report.elapsed() > report_threshold_1 {
+                if report.elapsed() > sleep_time {
+                    log::error!("Watchdog detecting async_std is stalled! No task scheduling since {} seconds", report.elapsed().as_secs_f32());
+                } else if report.elapsed() > report_threshold_2 {
+                    log::warn!("Watchdog detecting async_std was not scheduling tasks during the last {} ms", report.elapsed().as_micros());
+                } else {
+                    log::info!("Watchdog detecting async_std was not scheduling tasks during the last {} ms", report.elapsed().as_micros());
+                }
+            }
+        }
+    });
 }


### PR DESCRIPTION
Add a `--watchdog=[Period]` option to `zenoh-bridge-dds` (default period is 1 second).

Setting this option makes the `zenoh-bridge-dds` to spawn an extra thread that wakes up every `period` and uses a [LivelinessMonitor](https://github.com/p-avital/liveliness-monitor) to check if the async scheduler did not spend too much time not scheduling any task.
It logs messages depending the elapsed time since the last scheduled task:
 - at `error` level if elapsed time > `period`
 - at `warn` level if elapsed time > `100 ms`
 - at `info` level if elapsed time > `10 ms`