### PR TITLE
Add --queries-timeout option

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -90,6 +90,14 @@
       ////                           is used, meaning the route might drop some data in case of congestion.
       ////
       // reliable_routes_blocking: true,
+
+      ////
+      //// queries_timeout: A duration in seconds (default: 5.0 sec) that will be used as a timeout when the bridge
+      ////                  queries any other remote bridge for discovery information and for historical data for TRANSIENT_LOCAL DDS Readers it serves
+      ////                  (i.e. if the query to the remote bridge exceed the timeout, some historical samples might be not routed to the Readers,
+      ////                  but the route will not be blocked forever).
+      ////
+      // queries_timeout: 5.0,
     },
 
     ////

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ The `"dds"` part of this same configuration file can also be used in the configu
    - **`--rest-http-port <rest-http-port>`** : set the REST API http port (default: 8000)
  * DDS-related arguments:
    - **`-d, --domain <ID>`** : The DDS Domain ID. By default set to `0`, or to `"$ROS_DOMAIN_ID"` is this environment variable is defined.
-   - **`dds-localhost-only`** : If set, the DDS discovery and traffic will occur only on the localhost interface (127.0.0.1).
+   - **`--dds-localhost-only`** : If set, the DDS discovery and traffic will occur only on the localhost interface (127.0.0.1).
      By default set to false, unless the "ROS_LOCALHOST_ONLY=1" environment variable is defined.
    - **`-f, --fwd-discovery`** : When set, rather than creating a local route when discovering a local DDS entity, this discovery info is forwarded to the remote plugins/bridges. Those will create the routes, including a replica of the discovered entity. More details [here](#full-support-of-ros-graph-and-topic-lists-via-the-forward-discovery-mode)
    - **`-s, --scope <String>`** : A string used as prefix to scope DDS traffic when mapped to zenoh keys.
@@ -254,6 +254,10 @@ The `"dds"` part of this same configuration file can also be used in the configu
        - `"float"` is the maximum frequency in Hertz; if publication rate is higher, downsampling will occur when routing.
 
        (usable multiple times)
+   - **`--queries-timeout <Duration>`**: A duration in seconds (default: 5.0 sec) that will be used as a timeout when the bridge
+     queries any other remote bridge for discovery information and for historical data for TRANSIENT_LOCAL DDS Readers it serves
+     (i.e. if the query to the remote bridge exceed the timeout, some historical samples might be not routed to the Readers,
+     but the route will not be blocked forever).
    - **`-w, --generalise-pub <String>`** :  A list of key expressions to use for generalising the declaration of
      the zenoh publications, and thus minimizing the discovery traffic (usable multiple times).
      See [this blog](https://zenoh.io/blog/2021-03-23-discovery/#leveraging-resource-generalisation) for more details.

--- a/zenoh-bridge-dds/src/main.rs
+++ b/zenoh-bridge-dds/src/main.rs
@@ -135,6 +135,11 @@ r#"-f, --fwd-discovery   'When set, rather than creating a local route when disc
             ).alias("forward-discovery")
         )
         .arg(Arg::from_usage(
+r#"--queries-timeout=[float]... 'A float in seconds (default: 5.0 sec) that will be used as a timeout when the bridge
+queries any other remote bridge for discovery information and for historical data for TRANSIENT_LOCAL DDS Readers it serves
+(i.e. if the query to the remote bridge exceed the timeout, some historical samples might be not routed to the Readers, but the route will not be blocked forever)."#
+        ))
+        .arg(Arg::from_usage(
 r#"--watchdog=[PERIOD]   'Experimental!! Run a watchdog thread that monitors the bridge's async executor and reports as error log any stalled status during the specified period (default: 1.0 second)'"#
         ).default_missing_value("1.0"));
     let args = app.get_matches();
@@ -198,6 +203,7 @@ r#"--watchdog=[PERIOD]   'Experimental!! Run a watchdog thread that monitors the
     insert_json5!(config, args, "plugins/dds/max_frequencies", for "max-frequency", .collect::<Vec<_>>());
     insert_json5!(config, args, "plugins/dds/generalise_pubs", for "generalise-pub", .collect::<Vec<_>>());
     insert_json5!(config, args, "plugins/dds/generalise_subs", for "generalise-sub", .collect::<Vec<_>>());
+    insert_json5!(config, args, "plugins/dds/queries_timeout", if "queries-timeout", .parse::<f64>().unwrap());
     if args.is_present("fwd-discovery") {
         config
             .insert_json5("plugins/dds/forward_discovery", "true")

--- a/zplugin-dds/src/config.rs
+++ b/zplugin-dds/src/config.rs
@@ -21,6 +21,7 @@ pub const DEFAULT_DOMAIN: u32 = 0;
 pub const DEFAULT_GROUP_LEASE_SEC: f64 = 3.0;
 pub const DEFAULT_FORWARD_DISCOVERY: bool = false;
 pub const DEFAULT_RELIABLE_ROUTES_BLOCKING: bool = true;
+pub const DEFAULT_QUERIES_TIMEOUT: f32 = 5.0;
 pub const DEFAULT_DDS_LOCALHOST_ONLY: bool = false;
 
 #[derive(Deserialize, Debug)]
@@ -53,6 +54,11 @@ pub struct Config {
     pub reliable_routes_blocking: bool,
     #[serde(default = "default_localhost_only")]
     pub localhost_only: bool,
+    #[serde(
+        default = "default_queries_timeout",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub queries_timeout: Duration,
     #[serde(default)]
     __required__: bool,
     #[serde(default, deserialize_with = "deserialize_paths")]
@@ -144,6 +150,18 @@ where
         result.push((regex, frequency));
     }
     Ok(result)
+}
+
+fn default_queries_timeout() -> Duration {
+    Duration::from_secs_f32(DEFAULT_QUERIES_TIMEOUT)
+}
+
+fn deserialize_duration<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let seconds: f32 = Deserialize::deserialize(deserializer)?;
+    Ok(Duration::from_secs_f32(seconds))
 }
 
 fn default_forward_discovery() -> bool {

--- a/zplugin-dds/src/route_zenoh_dds.rs
+++ b/zplugin-dds/src/route_zenoh_dds.rs
@@ -283,12 +283,7 @@ impl RouteZenohDDS<'_> {
                 s
             );
             if let Err(e) = sub
-                .query_on(
-                    &s,
-                    QueryTarget::All,
-                    ConsolidationMode::None,
-                    query_timeout,
-                )
+                .query_on(&s, QueryTarget::All, ConsolidationMode::None, query_timeout)
                 .res()
                 .await
             {

--- a/zplugin-dds/src/route_zenoh_dds.rs
+++ b/zplugin-dds/src/route_zenoh_dds.rs
@@ -34,8 +34,6 @@ use crate::{
 type AtomicDDSEntity = AtomicI32;
 const DDS_ENTITY_NULL: dds_entity_t = 0;
 
-const TIMEOUT_HISTORICAL_PUB_QUERY: f32 = 5.0;
-
 enum ZSubscriber<'a> {
     Subscriber(Subscriber<'a, ()>),
     QueryingSubscriber(QueryingSubscriber<'a, ()>),
@@ -179,6 +177,7 @@ impl RouteZenohDDS<'_> {
                 .callback(subscriber_callback)
                 .allowed_origin(Locality::Remote) // Allow only remote publications to avoid loops
                 .reliable()
+                .query_timeout(plugin.config.queries_timeout)
                 .query_selector(query_selector)
                 .res()
                 .await
@@ -268,8 +267,11 @@ impl RouteZenohDDS<'_> {
 
     /// If this route uses a QueryingSubscriber, query for historical publications
     /// using the specified Selector. Otherwise, do nothing.
-    pub(crate) async fn query_historical_publications<'a, F>(&mut self, selector: F)
-    where
+    pub(crate) async fn query_historical_publications<'a, F>(
+        &mut self,
+        selector: F,
+        query_timeout: Duration,
+    ) where
         F: Fn() -> Selector<'a>,
     {
         if let ZSubscriber::QueryingSubscriber(sub) = &mut self.zenoh_subscriber {
@@ -285,7 +287,7 @@ impl RouteZenohDDS<'_> {
                     &s,
                     QueryTarget::All,
                     ConsolidationMode::None,
-                    Duration::from_secs_f32(TIMEOUT_HISTORICAL_PUB_QUERY),
+                    query_timeout,
                 )
                 .res()
                 .await


### PR DESCRIPTION
Add a `--queries-timeout` option to `zenoh-bridge-dds` and a `queries_timeout` attribute to the JSON config.

This option is a duration in seconds (default value 5.0 sec).
It allows to configure the timeout for all queries made by the bridge to another bridge:
 - query of historical publications from TRANSIENT_LOCAL DDS Writers
 - in forwarding mode, query of discovery information from remote bridge