### PR TITLE
Fix CycloneDDS warning 'NetworkInterfaceAddress: deprecated element'

### DIFF
--- a/zplugin-dds/src/lib.rs
+++ b/zplugin-dds/src/lib.rs
@@ -81,7 +81,7 @@ lazy_static::lazy_static!(
 // CycloneDDS' localhost-only: set network interface address (shortened form of config would be
 // possible, too, but I think it is clearer to spell it out completely).
 // Empty configuration fragments are ignored, so it is safe to unconditionally append a comma.
-const CYCLONEDDS_CONFIG_LOCALHOST_ONLY: &str = r#"<CycloneDDS><Domain><General><NetworkInterfaceAddress>127.0.0.1</NetworkInterfaceAddress></General></Domain></CycloneDDS>,"#;
+const CYCLONEDDS_CONFIG_LOCALHOST_ONLY: &str = r#"<CycloneDDS><Domain><General><Interfaces><NetworkInterface address="127.0.0.1" multicast="true"/></Interfaces></General></Domain></CycloneDDS>,"#;
 
 const GROUP_NAME: &str = "zenoh-plugin-dds";
 


### PR DESCRIPTION
Using the `--dds-localhost-only` this warning is displayed by CycloneDDS 0.10:
`1675348590.824894 [0] async-std/: config: //CycloneDDS/Domain/General: 'NetworkInterfaceAddress': deprecated element (CYCLONEDDS_URI+0 line 1)``

This PR updates the CycloneDDS configuration used with this option to latest syntax:
`<CycloneDDS><Domain><General><Interfaces><NetworkInterface address="127.0.0.1" multicast="true"/></Interfaces></General></Domain></CycloneDDS>`

NOTE: force `multicast="true"` since multicast is always working on localhost, even if on some Ubuntu the MULTICAST flag is not set for this interface. See https://github.com/eclipse-cyclonedds/cyclonedds/issues/1400#issuecomment-1241575011