### PR TITLE
Able to repeat allow and deny option.

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -42,17 +42,19 @@
       //// allow: A regular expression matching the set of 'partition/topic-name' that must be routed via zenoh.
       ////        By default, all partitions and topics are allowed.
       ////        If both 'allow' and 'deny' are set a partition and/or topic will be allowed if it matches only the 'allow' expression.
+      ////        Repeat this option to configure several topic expressions. These expressions are concatenated with '|'.
       ////        Examples of expressions: ".*/TopicA", "Partition-?/.*", "cmd_vel|rosout"...'"#
       ////
-      // allow: "cmd_vel|rosout",
+      // allow: ["cmd_vel", "rosout"],
 
       ////
       //// deny:  A regular expression matching the set of 'partition/topic-name' that must NOT be routed via zenoh.
       ////        By default, no partitions and no topics are denied.
       ////        If both 'allow' and 'deny' are set a partition and/or topic will be allowed if it matches only the 'allow' expression.
+      ////        Repeat this option to configure several topic expressions. These expressions are concatenated with '|'.
       ////        Examples of expressions: ".*/TopicA", "Partition-?/.*", "cmd_vel|rosout"...'"#
       ////
-      // deny: "cmd_vel|rosout",
+      // deny: ["cmd_vel", "rosout"],
 
       ////
       //// max_frequencies: Specifies a list of maximum frequency of data routing over zenoh for a set of topics.

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ The `"dds"` part of this same configuration file can also be used in the configu
    - **`-a, --allow <String>`** :  A regular expression matching the set of 'partition/topic-name' that must be routed via zenoh.
      By default, all partitions and topics are allowed.  
      If both 'allow' and 'deny' are set a partition and/or topic will be allowed if it matches only the 'allow' expression.  
+     Repeat this option to configure several topic expressions. These expressions are concatenated with '|'.
      Examples of expressions: 
         - `.*/TopicA` will allow only the `TopicA` to be routed, whatever the partition.
         - `PartitionX/.*` will allow all the topics to be routed, but only on `PartitionX`.
@@ -251,6 +252,7 @@ The `"dds"` part of this same configuration file can also be used in the configu
    - **`--deny <String>`** :  A regular expression matching the set of 'partition/topic-name' that must NOT be routed via zenoh.
      By default, no partitions and no topics are denied.  
      If both 'allow' and 'deny' are set a partition and/or topic will be allowed if it matches only the 'allow' expression.  
+     Repeat this option to configure several topic expressions. These expressions are concatenated with '|'.
    - **`--max-frequency <String>...`** : specifies a maximum frequency of data routing over zenoh per-topic. The string must have the format `"regex=float"` where:
        - `"regex"` is a regular expression matching the set of 'partition/topic-name' for which the data (per DDS instance) must be routedat no higher rate than associated max frequency (same syntax than --allow option).
        - `"float"` is the maximum frequency in Hertz; if publication rate is higher, downsampling will occur when routing.

--- a/zenoh-bridge-dds/src/main.rs
+++ b/zenoh-bridge-dds/src/main.rs
@@ -108,13 +108,15 @@ r#"--group-lease=[Duration]   'The lease duration (in seconds) used in group man
             .default_value(&DEFAULT_GROUP_LEASE_STR)
         )
         .arg(Arg::from_usage(
-r#"-a, --allow=[String]   'A regular expression matching the set of 'partition/topic-name' that must be routed via zenoh. By default, all partitions and topics are allowed.
+r#"-a, --allow=[String]...   'A regular expression matching the set of 'partition/topic-name' that must be routed via zenoh. By default, all partitions and topics are allowed.
 If both '--allow' and '--deny' are set a partition and/or topic will be allowed if it matches only the 'allow' expression.
+Repeat this option to configure several topic expressions. These expressions are concatenated with '|'.
 Examples of expressions: '.*/TopicA', 'Partition-?/.*', 'cmd_vel|rosout'...'"#
         ))
         .arg(Arg::from_usage(
-r#"--deny=[String]   'A regular expression matching the set of 'partition/topic-name' that must not be routed via zenoh. By default, no partitions and no topics are denied.
+r#"--deny=[String]...   'A regular expression matching the set of 'partition/topic-name' that must not be routed via zenoh. By default, no partitions and no topics are denied.
 If both '--allow' and '--deny' are set a partition and/or topic will be allowed if it matches only the 'allow' expression.
+Repeat this option to configure several topic expressions. These expressions are concatenated with '|'.
 Examples of expressions: '.*/TopicA', 'Partition-?/.*', 'cmd_vel|rosout'...'"#
         ))
         .arg(Arg::from_usage(
@@ -198,8 +200,8 @@ r#"--watchdog=[PERIOD]   'Experimental!! Run a watchdog thread that monitors the
     insert_json5!(config, args, "plugins/dds/localhost_only", if "dds-localhost-only");
     insert_json5!(config, args, "plugins/dds/group_member_id", if "group-member-id", );
     insert_json5!(config, args, "plugins/dds/group_lease", if "group-lease", .parse::<f64>().unwrap());
-    insert_json5!(config, args, "plugins/dds/allow", if "allow", );
-    insert_json5!(config, args, "plugins/dds/deny", if "deny", );
+    insert_json5!(config, args, "plugins/dds/allow", for "allow", .collect::<Vec<_>>());
+    insert_json5!(config, args, "plugins/dds/deny", for "deny", .collect::<Vec::<_>>());
     insert_json5!(config, args, "plugins/dds/max_frequencies", for "max-frequency", .collect::<Vec<_>>());
     insert_json5!(config, args, "plugins/dds/generalise_pubs", for "generalise-pub", .collect::<Vec<_>>());
     insert_json5!(config, args, "plugins/dds/generalise_subs", for "generalise-sub", .collect::<Vec<_>>());

--- a/zplugin-dds/src/config.rs
+++ b/zplugin-dds/src/config.rs
@@ -123,7 +123,8 @@ fn deserialize_regex<'de, D>(deserializer: D) -> Result<Option<Regex>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let s: String = Deserialize::deserialize(deserializer)?;
+    let strs: Vec<String> = Deserialize::deserialize(deserializer)?;
+    let s: String = strs.join("|");
     Regex::new(&s)
         .map(Some)
         .map_err(|e| de::Error::custom(format!("Invalid regex 'allow={s}': {e}")))


### PR DESCRIPTION
As mentioned in #116, it would be helpful to support list instead of string only for allow and deny option.

This PR allows us to split the topic expressions into several more readable parts.
