### PR TITLE
Remove unnecessary block_on

### DIFF
--- a/zenoh-bridge-dds/src/main.rs
+++ b/zenoh-bridge-dds/src/main.rs
@@ -239,7 +239,7 @@ async fn main() {
     // start DDS plugin
     use zenoh_plugin_trait::Plugin;
     zplugin_dds::DDSPlugin::start("dds", &runtime).unwrap();
-    async_std::task::block_on(async_std::future::pending::<()>());
+    async_std::future::pending::<()>().await;
 }
 
 fn run_watchdog(period: f32) {


### PR DESCRIPTION
`block_on` on a pending future will steal the thread from the executor.
Better awaiting and the pending future instead.