### PR TITLE
Put binary "zenoh-bridge-dds" into bin folder while colcon build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,10 +47,17 @@ add_custom_target(
         ${RUST_TARGET_DIR}/release/zenoh-bridge-dds
 )
 
-install(FILES
-    ${RUST_TARGET_DIR}/release/zenoh-bridge-dds
-    PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-    DESTINATION bin
-)
+macro(INSTALL_ZENOH src_path dst_path)
+  install(FILES
+      ${src_path}
+      RENAME zenoh_bridge_dds
+      PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+      DESTINATION ${dst_path}
+  )
+endmacro(INSTALL_ZENOH)
+
+INSTALL_ZENOH(${RUST_TARGET_DIR}/release/zenoh-bridge-dds lib/${PROJECT_NAME})
+
+INSTALL_ZENOH(${RUST_TARGET_DIR}/release/zenoh-bridge-dds bin)
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,9 +49,8 @@ add_custom_target(
 
 install(FILES
     ${RUST_TARGET_DIR}/release/zenoh-bridge-dds
-    RENAME zenoh_bridge_dds
     PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-    DESTINATION lib/${PROJECT_NAME}
+    DESTINATION bin
 )
 
 ament_package()


### PR DESCRIPTION
After running ROS 2 colcon build, the binary (zenoh-bridge-dds) is put under `install/zenoh_bridge_dds/lib/` folder, which can not be used directly when we source `install/setup.bash`
I move the binary to `install/zenoh_bridge_dds/bin/` and also rename the binary name to zenoh-bridge-dds (The same name if we build with `cargo build`).