### PR TITLE
Modified formatting of sample payload in trace logs

### DIFF
--- a/zenoh-plugin-dds/src/dds_mgt.rs
+++ b/zenoh-plugin-dds/src/dds_mgt.rs
@@ -254,7 +254,7 @@ unsafe extern "C" fn data_forwarder_listener(dr: dds_entity_t, arg: *mut std::os
 
             if *crate::LOG_PAYLOAD {
                 log::trace!(
-                    "Route data from DDS {} to zenoh key={} - payload: {:?}",
+                    "Route data from DDS {} to zenoh key={} - payload: {:02x?}",
                     &(*pa).0,
                     &(*pa).1,
                     data_in_slice


### PR DESCRIPTION
This PR modifies the formatting of the sample payload in trace logging to be lowercase hexadecimal rather than decimal. This is to ensure consistency within the application as Zenoh payloads received across the bridge are logged in hexadecimal format.