### PR TITLE
Corrected handling of Iceoryx buffer content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,7 +903,7 @@ dependencies = [
 [[package]]
 name = "cyclors"
 version = "0.2.0"
-source = "git+https://github.com/kydos/cyclors?branch=master#c6e5ed43ef1cfeeedc2657a7d2aece38755a634e"
+source = "git+https://github.com/kydos/cyclors?branch=master#45d50e7c71584c1cd7468f95f400cdc43a944f71"
 dependencies = [
  "bincode",
  "bindgen",
@@ -3576,7 +3576,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 

--- a/zenoh-plugin-dds/src/dds_mgt.rs
+++ b/zenoh-plugin-dds/src/dds_mgt.rs
@@ -153,11 +153,12 @@ impl DDSRawSample {
                         (*serdata).kind,
                         (*serdata).iox_chunk,
                     );
-                
+
                     let size = ddsi_serdata_size(serialized_serdata);
-                    sdref = ddsi_serdata_to_ser_ref(serialized_serdata, 0, size as usize, &mut data);
+                    sdref =
+                        ddsi_serdata_to_ser_ref(serialized_serdata, 0, size as usize, &mut data);
                     ddsi_serdata_unref(serialized_serdata);
-                    
+
                     // IoxChunk not needed where raw data has been serialized
                     None
                 } else {
@@ -180,10 +181,13 @@ impl DDSRawSample {
         }
 
         #[cfg(feature = "dds_shm")]
-        return DDSRawSample { sdref, data, iox_chunk };
+        return DDSRawSample {
+            sdref,
+            data,
+            iox_chunk,
+        };
         #[cfg(not(feature = "dds_shm"))]
         return DDSRawSample { sdref, data };
-
     }
 
     fn data_as_slice(&self) -> &[u8] {


### PR DESCRIPTION
The implementation now serializes raw samples when received via an Iceoryx buffer before forwarding it onto Zenoh. This ensures onward applications receive samples in a consistent format.

This is currently a draft PR as this requires an update to Cyclors in order to compile: https://github.com/kydos/cyclors/pull/15