### PR TITLE
Update Cyclors to latest version for Qos changes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
 [[package]]
 name = "cyclors"
 version = "0.2.0"
-source = "git+https://github.com/kydos/cyclors?branch=master#8f831b3b0a7fc8a63098a82a5c079dc3562405a7"
+source = "git+https://github.com/kydos/cyclors?branch=master#c1be4c46e652e4234bd5c25369f990ad0fc3f386"
 dependencies = [
  "bincode",
  "bindgen",
@@ -3617,7 +3617,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 


### PR DESCRIPTION
Default Qos values are now represented as None in Qos struct.