### PR TITLE
When ROS_LOCALHOST_ONLY=1 don't force multicast on lo (fix #158)

### DIFF
--- a/zenoh-plugin-dds/src/lib.rs
+++ b/zenoh-plugin-dds/src/lib.rs
@@ -93,7 +93,7 @@ lazy_static::lazy_static!(
 // CycloneDDS' localhost-only: set network interface address (shortened form of config would be
 // possible, too, but I think it is clearer to spell it out completely).
 // Empty configuration fragments are ignored, so it is safe to unconditionally append a comma.
-const CYCLONEDDS_CONFIG_LOCALHOST_ONLY: &str = r#"<CycloneDDS><Domain><General><Interfaces><NetworkInterface address="127.0.0.1" multicast="true"/></Interfaces></General></Domain></CycloneDDS>,"#;
+const CYCLONEDDS_CONFIG_LOCALHOST_ONLY: &str = r#"<CycloneDDS><Domain><General><Interfaces><NetworkInterface address="127.0.0.1"/></Interfaces></General></Domain></CycloneDDS>,"#;
 
 // CycloneDDS' enable-shm: enable usage of Iceoryx shared memory
 #[cfg(feature = "dds_shm")]


### PR DESCRIPTION
This makes the bridge to follow the same behaviour than ROS 2 with `rmw_cyclonedds_cpp` when `ROS_LOCALHOST_ONLY=1`: just make CycloneDDS to use `127.0.0.1` not forcing `multicast=true`, and thus avoiding discovery issue with ROS Nodes that don't force multicast usage.

See https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/issues/12#issuecomment-1792248458 for more details.