### PR TITLE
Encourage ros2dds bridge usage for ROS 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Thanks to a better integration with ROS 2 concepts, this new plugin comes with t
 - Services and Action as **Zenoh Queryables** with more efficiency and scalability that RPC over DDS
 - Even more **compact discovery information** between the bridges (not forwarding all `ros_discovery_info` messages as such)
 
-This DDS plugin for Zenoh will eventually be deprecated for ROS 2 usage.
+This Zenoh plugin for DDS will eventually be deprecated for ROS 2 usage.
 
 ## Plugin or bridge ?
 

--- a/zenoh-plugin-dds/src/lib.rs
+++ b/zenoh-plugin-dds/src/lib.rs
@@ -29,8 +29,8 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::env;
 use std::mem::ManuallyDrop;
-use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use std::time::Duration;
 use zenoh::buffers::SplitBuffer;
 use zenoh::liveliness::LivelinessToken;
@@ -106,11 +106,12 @@ const ROS_DISCOVERY_INFO_POLL_INTERVAL_MS: u64 = 500;
 
 zenoh_plugin_trait::declare_plugin!(DDSPlugin);
 
-
 fn log_ros2_deprecation_warning() {
-    if ! LOG_ROS2_DEPRECATION_WARNING_FLAG.swap(true, std::sync::atomic::Ordering::Relaxed) {
+    if !LOG_ROS2_DEPRECATION_WARNING_FLAG.swap(true, std::sync::atomic::Ordering::Relaxed) {
         log::warn!("------------------------------------------------------------------------------------------");
-        log::warn!("ROS 2 system detected. Did you now a new Zenoh bridge dedicated to ROS 2 exists ?");
+        log::warn!(
+            "ROS 2 system detected. Did you now a new Zenoh bridge dedicated to ROS 2 exists ?"
+        );
         log::warn!("Check it out on https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds");
         log::warn!("This DDS bridge will eventually be deprecated for ROS 2 usage in favor of this new bridge.");
         log::warn!("------------------------------------------------------------------------------------------");

--- a/zenoh-plugin-dds/src/lib.rs
+++ b/zenoh-plugin-dds/src/lib.rs
@@ -30,6 +30,7 @@ use std::convert::TryInto;
 use std::env;
 use std::mem::ManuallyDrop;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 use zenoh::buffers::SplitBuffer;
 use zenoh::liveliness::LivelinessToken;
@@ -88,6 +89,8 @@ lazy_static::lazy_static!(
 
     static ref KE_ANY_1_SEGMENT: &'static keyexpr = ke_for_sure!("*");
     static ref KE_ANY_N_SEGMENT: &'static keyexpr = ke_for_sure!("**");
+
+    static ref LOG_ROS2_DEPRECATION_WARNING_FLAG: AtomicBool = AtomicBool::new(false);
 );
 
 // CycloneDDS' localhost-only: set network interface address (shortened form of config would be
@@ -102,6 +105,17 @@ const CYCLONEDDS_CONFIG_ENABLE_SHM: &str = r#"<CycloneDDS><Domain><SharedMemory>
 const ROS_DISCOVERY_INFO_POLL_INTERVAL_MS: u64 = 500;
 
 zenoh_plugin_trait::declare_plugin!(DDSPlugin);
+
+
+fn log_ros2_deprecation_warning() {
+    if ! LOG_ROS2_DEPRECATION_WARNING_FLAG.swap(true, std::sync::atomic::Ordering::Relaxed) {
+        log::warn!("------------------------------------------------------------------------------------------");
+        log::warn!("ROS 2 system detected. Did you now a new Zenoh bridge dedicated to ROS 2 exists ?");
+        log::warn!("Check it out on https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds");
+        log::warn!("This DDS bridge will eventually be deprecated for ROS 2 usage in favor of this new bridge.");
+        log::warn!("------------------------------------------------------------------------------------------");
+    }
+}
 
 #[allow(clippy::upper_case_acronyms)]
 pub struct DDSPlugin;
@@ -335,6 +349,10 @@ lazy_static::lazy_static! {
 
 impl<'a> DdsPluginRuntime<'a> {
     fn is_allowed(&self, ke: &keyexpr) -> bool {
+        if ke.ends_with(ROS_DISCOVERY_INFO_TOPIC_NAME) {
+            log_ros2_deprecation_warning();
+        }
+
         if self.config.forward_discovery && ke.ends_with(ROS_DISCOVERY_INFO_TOPIC_NAME) {
             // If fwd-discovery mode is enabled, don't route "ros_discovery_info"
             return false;


### PR DESCRIPTION
A new Zenoh plugin dedicated for ROS 2 has been developed:
https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds

We strongly advise ROS 2 users to use it, since it better integrates with ROS 2 and brings these benefits:

- Better integration of the **ROS graph** (all ROS topics/services/actions can be seen across bridges)
- Better support of **ROS toolings** (ros2 CLI, rviz2...)
- Configuration of a **ROS namespace** on the bridge (instead of on each ROS Node)
- Services and Action as **Zenoh Queryables** with more efficiency and scalability that RPC over DDS
- Even more **compact discovery information** between the bridges (not forwarding all `ros_discovery_info` messages as such)

The Zenoh plugin for DDS will eventually be deprecated for ROS 2 usage.
