### PR TITLE
Config: accept 'null' for allow/deny (fix #169)

### DIFF
--- a/zenoh-plugin-dds/src/config.rs
+++ b/zenoh-plugin-dds/src/config.rs
@@ -199,6 +199,14 @@ impl<'de> Visitor<'de> for RegexVisitor {
         formatter.write_str(r#"either a string or a list of strings"#)
     }
 
+    // for `null` value
+    fn visit_unit<E>(self) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+    {
+        Ok(None)
+    }
+
     fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
     where
         E: de::Error,


### PR DESCRIPTION
Note: strangely on `Value::Null` deserialization serde_json is calling `Visitor::visit_unit()` and not `Visitor::visit_none()` as one could expect.
See: https://github.com/serde-rs/json/blob/05196caf16456cfe6e738e946f459691c5fbf0c6/src/value/de.rs#L217