### PR TITLE
zenoh-bridge-dds: fix static loading of plugin

### DIFF
--- a/zenoh-plugin-dds/src/lib.rs
+++ b/zenoh-plugin-dds/src/lib.rs
@@ -125,7 +125,7 @@ impl Plugin for DDSPlugin {
     type StartArgs = Runtime;
     type Instance = RunningPlugin;
 
-    const DEFAULT_NAME: &'static str = "zenoh-plugin-dds";
+    const DEFAULT_NAME: &'static str = "dds";
     const PLUGIN_VERSION: &'static str = plugin_version!();
     const PLUGIN_LONG_VERSION: &'static str = plugin_long_version!();
 


### PR DESCRIPTION
Make the `zenoh-bridge-dds` to use the PluginManager to declare the static plugins, rather than relying on the `zenoh::open()` that would try to load the plugins as dynamic lib.

Fix #221  