### PR TITLE
Admin space: change prefix from '@/service/<uuid>/dds' to '@dds/<uuid>'

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,26 +236,28 @@ The `"dds"` part of this same configuration file can also be used in the configu
 The zenoh bridge for DDS exposes an administration space allowing to browse the DDS entities that have been discovered (with their QoS), and the routes that have been established between DDS and zenoh.
 This administration space is accessible via any zenoh API, including the REST API that you can activate at `zenoh-bridge-dds` startup using the `--rest-http-port` argument.
 
-The `zenoh-bridge-dds` exposes this administration space with paths prefixed by `@/service/<uuid>/dds` (where `<uuid>` is the unique identifier of the bridge instance). The informations are then organized with such paths:
- - `@/service/<uuid>/dds/version` : the bridge version
- - `@/service/<uuid>/dds/config` : the bridge configuration
- - `@/service/<uuid>/dds/participant/<gid>/reader/<gid>/<topic>` : a discovered DDS reader on `<topic>`
- - `@/service/<uuid>/dds/participant/<gid>/writer/<gid>/<topic>` : a discovered DDS reader on `<topic>`
- - `@/service/<uuid>/dds/route/from_dds/<zenoh-resource>` : a route established from a DDS writer to a zenoh key named `<zenoh-resource>` (see [mapping rules](#mapping-dds-topics-to-zenoh-resources)).
- - `@/service/<uuid>/dds/route/to_dds/<zenoh-resource>` : a route established from a zenoh key named `<zenoh-resource>` (see [mapping rules](#mapping-dds-topics-to-zenoh-resources))..
+Starting from version `0.11.0-rc.2`, the `zenoh-bridge-dds` exposes this administration space with paths prefixed by `@dds/<uuid>` (where `<uuid>` is the unique identifier of the bridge instance). The informations are then organized with such paths:
+ - `@dds/<uuid>/version` : the bridge version
+ - `@dds/<uuid>/config` : the bridge configuration
+ - `@dds/<uuid>/participant/<gid>/reader/<gid>/<topic>` : a discovered DDS reader on `<topic>`
+ - `@dds/<uuid>/participant/<gid>/writer/<gid>/<topic>` : a discovered DDS reader on `<topic>`
+ - `@dds/<uuid>/route/from_dds/<zenoh-resource>` : a route established from a DDS writer to a zenoh key named `<zenoh-resource>` (see [mapping rules](#mapping-dds-topics-to-zenoh-resources)).
+ - `@dds/<uuid>/route/to_dds/<zenoh-resource>` : a route established from a zenoh key named `<zenoh-resource>` (see [mapping rules](#mapping-dds-topics-to-zenoh-resources))..
+
+For previous versions, see the corresponding version of README.md: [0.10.1-rc](https://github.com/eclipse-zenoh/zenoh-plugin-dds/blob/0.10.1-rc/README.md#admin-space).
 
 Example of queries on administration space using the REST API with the `curl` command line tool (don't forget to activate the REST API with `--rest-http-port 8000` argument):
  - List all the DDS entities that have been discovered:
     ```bash
-    curl http://localhost:8000/@/service/**/participant/**
+    curl http://localhost:8000/@dds/*/participant/**
     ```
  - List all established routes:
     ```bash
-    curl http://localhost:8000/@/service/**/route/**
+    curl http://localhost:8000/@dds/*/route/**
     ```
  - List all discovered DDS entities and established route for topic `cmd_vel`:
     ```bash
-    curl http://localhost:8000/@/service/**/cmd_vel
+    curl http://localhost:8000/@dds/**/cmd_vel
     ```
 
 > _Pro tip: pipe the result into [**jq**](https://stedolan.github.io/jq/) command for JSON pretty print or transformation._

--- a/zenoh-plugin-dds/src/lib.rs
+++ b/zenoh-plugin-dds/src/lib.rs
@@ -77,7 +77,7 @@ macro_rules! member_id {
 lazy_static::lazy_static!(
     static ref LOG_PAYLOAD: bool = std::env::var("Z_LOG_PAYLOAD").is_ok();
 
-    static ref KE_PREFIX_ADMIN_SPACE: &'static keyexpr = ke_for_sure!("@/service");
+    static ref KE_PREFIX_ADMIN_SPACE: &'static keyexpr = ke_for_sure!("@dds");
     static ref KE_PREFIX_ROUTE_TO_DDS: &'static keyexpr = ke_for_sure!("route/to_dds");
     static ref KE_PREFIX_ROUTE_FROM_DDS: &'static keyexpr = ke_for_sure!("route/from_dds");
     static ref KE_PREFIX_PUB_CACHE: &'static keyexpr = ke_for_sure!("@dds_pub_cache");
@@ -693,8 +693,7 @@ impl<'a> DdsPluginRuntime<'a> {
         run_discovery(self.dp, tx);
 
         // declare admin space queryable
-        let admin_keyexpr_prefix =
-            *KE_PREFIX_ADMIN_SPACE / &self.zsession.zid().into_keyexpr() / ke_for_sure!("dds");
+        let admin_keyexpr_prefix = *KE_PREFIX_ADMIN_SPACE / &self.zsession.zid().into_keyexpr();
         let admin_keyexpr_expr = (&admin_keyexpr_prefix) / *KE_ANY_N_SEGMENT;
         debug!("Declare admin space on {}", admin_keyexpr_expr);
         let admin_queryable = self
@@ -1171,7 +1170,7 @@ impl<'a> DdsPluginRuntime<'a> {
                             // it's a writer discovery message
                             "writer" => {
                                 // reconstruct full admin keyexpr for this entity (i.e. with it's remote plugin's uuid)
-                                let full_admin_keyexpr = *KE_PREFIX_ADMIN_SPACE / remote_uuid / ke_for_sure!("dds") / remaining_ke;
+                                let full_admin_keyexpr = *KE_PREFIX_ADMIN_SPACE / remote_uuid / remaining_ke;
                                 if sample.kind != SampleKind::Delete {
                                     // deserialize payload
                                     let (entity, scope) = match bincode::deserialize::<(DdsEntity, Option<OwnedKeyExpr>)>(&sample.payload.contiguous()) {
@@ -1251,7 +1250,7 @@ impl<'a> DdsPluginRuntime<'a> {
                             // it's a reader discovery message
                             "reader" => {
                                 // reconstruct full admin keyexpr for this entity (i.e. with it's remote plugin's uuid)
-                                let full_admin_keyexpr = *KE_PREFIX_ADMIN_SPACE / remote_uuid / ke_for_sure!("dds") / remaining_ke;
+                                let full_admin_keyexpr = *KE_PREFIX_ADMIN_SPACE / remote_uuid / remaining_ke;
                                 if sample.kind != SampleKind::Delete {
                                     // deserialize payload
                                     let (entity, scope) = match bincode::deserialize::<(DdsEntity, Option<OwnedKeyExpr>)>(&sample.payload.contiguous()) {
@@ -1391,7 +1390,7 @@ impl<'a> DdsPluginRuntime<'a> {
                             // remove all the references to the plugin's enities, removing no longer used routes
                             // and updating/re-publishing ParticipantEntitiesInfo
                             let admin_space = &mut self.admin_space;
-                            let admin_subke = format!("@/service/{mid}/dds/");
+                            let admin_subke = format!("@dds/{mid}/");
                             let mut participant_info_changed = false;
                             self.routes_to_dds.retain(|zkey, route| {
                                 route.remove_remote_routed_writers_containing(&admin_subke);


### PR DESCRIPTION
The plugin had its admin space under `@/service/<uuid>/dds/**`.
The main drawback is that it's mixed with Zenoh's admin space which is prefixed with `@/`.

For separation of concerns and for coherency with the plugin for ROS2 which uses `@ros2/<uuid>` as prefix, this PR changes the admin prefix for DDS plugin to `@dds/<uuid>`

Migration guide:
- `@/service/<uuid>/dds/version` becomes:
   `@dds/<uuid>/version`
- `@/service/<uuid>/dds/config` becomes:
   `@dds/<uuid>/config`
- `@/service/<uuid>/dds/participant/<gid>/reader/<gid>/<topic>` becomes:
   `@dds/<uuid>/participant/<gid>/reader/<gid>/<topic>`
- `@/service/<uuid>/dds/participant/<gid>/writer/<gid>/<topic>` becomes:
   `@dds/<uuid>/participant/<gid>/writer/<gid>/<topic>`
- `@/service/<uuid>/dds/route/from_dds/<zenoh-resource>` becomes:
   `@dds/<uuid>/route/from_dds/<zenoh-resource>`
- `@/service/<uuid>/dds/route/to_dds/<zenoh-resource>` becomes:
   `@dds/<uuid>/route/to_dds/<zenoh-resource>`