### PR TITLE
chore: renamed no_mangle feature to dynamic_plugin

### DIFF
--- a/zenoh-plugin-dds/Cargo.toml
+++ b/zenoh-plugin-dds/Cargo.toml
@@ -27,8 +27,8 @@ name = "zenoh_plugin_dds"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["no_mangle"]
-no_mangle = []
+default = ["dynamic_plugin"]
+dynamic_plugin = []
 dds_shm = ["cyclors/iceoryx"]
 stats = ["zenoh/stats"]
 

--- a/zenoh-plugin-dds/src/lib.rs
+++ b/zenoh-plugin-dds/src/lib.rs
@@ -101,7 +101,7 @@ const CYCLONEDDS_CONFIG_ENABLE_SHM: &str = r#"<CycloneDDS><Domain><SharedMemory>
 
 const ROS_DISCOVERY_INFO_POLL_INTERVAL_MS: u64 = 500;
 
-#[cfg(feature = "no_mangle")]
+#[cfg(feature = "dynamic_plugin")]
 zenoh_plugin_trait::declare_plugin!(DDSPlugin);
 
 fn log_ros2_deprecation_warning() {


### PR DESCRIPTION
As suggested by @milyin this PR renames the `no_mangle` feature to `dynamic_plugin` which is easier to understand.
- Sister of: https://github.com/eclipse-zenoh/zenoh/pull/1010