### PR TITLE
Align Rust with Reliability exported in zenoh::qos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4350,7 +4350,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4418,7 +4418,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "zenoh-collections",
 ]
@@ -4426,7 +4426,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "tracing",
  "uhlc",
@@ -4437,12 +4437,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 
 [[package]]
 name = "zenoh-config"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "json5",
  "num_cpus",
@@ -4463,7 +4463,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -4474,7 +4474,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "aes 0.8.4",
  "hmac 0.12.1",
@@ -4487,7 +4487,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "bincode",
  "flume",
@@ -4503,7 +4503,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "hashbrown 0.14.5",
  "keyed-set",
@@ -4517,7 +4517,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -4534,7 +4534,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "flume",
@@ -4557,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4582,7 +4582,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "socket2 0.5.7",
@@ -4599,7 +4599,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4626,7 +4626,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "socket2 0.5.7",
@@ -4645,7 +4645,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "nix",
@@ -4663,7 +4663,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4683,7 +4683,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4719,7 +4719,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-rest"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4743,7 +4743,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "git-version",
  "libloading",
@@ -4759,7 +4759,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "const_format",
  "rand 0.8.5",
@@ -4773,7 +4773,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "anyhow",
 ]
@@ -4781,7 +4781,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "lazy_static",
  "ron",
@@ -4794,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "event-listener 5.3.1",
  "futures",
@@ -4807,7 +4807,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "futures",
  "tokio",
@@ -4820,7 +4820,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -4853,7 +4853,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "1.0.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1b046d4781017bf588027c38dc3d3285dac024cd"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#a7599ef3ef184d19f1d297f48cb2099de9866ffb"
 dependencies = [
  "async-trait",
  "const_format",

--- a/zenoh-plugin-dds/src/route_dds_zenoh.rs
+++ b/zenoh-plugin-dds/src/route_dds_zenoh.rs
@@ -159,7 +159,7 @@ impl RouteDDSZenoh<'_> {
             if let Err(e) = plugin
                 .zsession
                 .declare_publisher(declared_ke.clone())
-                .reliability(zenoh::pubsub::Reliability::Reliable)
+                .reliability(zenoh::qos::Reliability::Reliable)
                 .await
             {
                 tracing::warn!(


### PR DESCRIPTION
Move zenoh::pubsub::Reliability to zenoh::qos::Reliability. To be merged after https://github.com/eclipse-zenoh/zenoh/pull/1457.