### PR TITLE
feat: ignore unknown configuration fileds

### DIFF
--- a/zenoh-plugin-dds/src/config.rs
+++ b/zenoh-plugin-dds/src/config.rs
@@ -26,7 +26,6 @@ pub const DEFAULT_WORK_THREAD_NUM: usize = 2;
 pub const DEFAULT_MAX_BLOCK_THREAD_NUM: usize = 50;
 
 #[derive(Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(default)]
     pub scope: Option<OwnedKeyExpr>,


### PR DESCRIPTION
This PR changes the behavior of the configuration parser to ignore unknown fields.
This allows to load the DDS plugin multiple times, and thus to connect to multiple DDS domains at once.
See how to load a plugin multiple times in Zenoh: https://github.com/eclipse-zenoh/zenoh/pull/1060