### PR TITLE
fix: set bump-deps-pattern to default to zenoh.*

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       version: ${{ inputs.version }}
       branch: ${{ inputs.branch }}
       bump-deps-version: ${{ inputs.zenoh-version }}
-      bump-deps-pattern: ${{ inputs.zenoh-version && 'zenoh.*' || '^$' }}
+      bump-deps-pattern: 'zenoh.*'
       bump-deps-branch: ${{ inputs.zenoh-version && format('release/{0}', inputs.zenoh-version) || '' }}
     secrets: inherit
 


### PR DESCRIPTION
This way for scheduled events the input will be correctly set.
See https://github.com/eclipse-zenoh/zenoh-plugin-dds/actions/runs/13935976471/job/39003823235