### PR TITLE
Fix build with Rust 1.75

### DIFF
--- a/zenoh-plugin-dds/src/qos_helpers.rs
+++ b/zenoh-plugin-dds/src/qos_helpers.rs
@@ -28,9 +28,10 @@ pub(crate) fn get_durability_service_or_default(qos: &Qos) -> DurabilityService 
 }
 
 pub(crate) fn partition_is_empty(partition: &Option<Vec<String>>) -> bool {
+    #[allow(clippy::unnecessary_map_or)] // Option::is_none_or() doesn't exist in Rust 1.75
     partition
         .as_ref()
-        .is_none_or(|partition| partition.is_empty())
+        .map_or(true, |partition| partition.is_empty())
 }
 
 pub(crate) fn partition_contains(partition: &Option<Vec<String>>, name: &String) -> bool {
@@ -40,9 +41,10 @@ pub(crate) fn partition_contains(partition: &Option<Vec<String>>, name: &String)
 }
 
 pub(crate) fn is_writer_reliable(reliability: &Option<Reliability>) -> bool {
-    reliability
-        .as_ref()
-        .is_none_or(|reliability| reliability.kind == ReliabilityKind::RELIABLE)
+    #[allow(clippy::unnecessary_map_or)] // Option::is_none_or() doesn't exist in Rust 1.75
+    reliability.as_ref().map_or(true, |reliability| {
+        reliability.kind == ReliabilityKind::RELIABLE
+    })
 }
 
 pub(crate) fn is_reader_reliable(reliability: &Option<Reliability>) -> bool {


### PR DESCRIPTION
Revert a change from #449 which was not compatible with Rust 1.75.
[`std::option::Option::is_none_or()`](https://doc.rust-lang.org/nightly/std/option/enum.Option.html#method.is_none_or) was introduced since Rust 1.82.