### PR TITLE
chore: use windows-2022 image for cmake 3.31

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,8 @@ jobs:
       # cyclors 0.3.x does not compile with cmake 4
       - name: Install cmake
         uses: jwlawson/actions-setup-cmake@v2
-        with: 
-          cmake-version: '3.31.x'
+        with:
+          cmake-version: "3.31.x"
 
       - name: Install LLVM toolchain
         if: startsWith(matrix.os,'macos')
@@ -112,8 +112,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DavidAnson/markdownlint-cli2-action@v18
         with:
-          config: '.markdownlint.yaml'
-          globs: '**/README.md'
+          config: ".markdownlint.yaml"
+          globs: "**/README.md"
 
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest, windows-2022]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The windows-latest runner https://github.com/actions/runner-images/issues/14017 updates the VS tooling in the runner to an incompatible version with cmake 3 required by cyclors dependency

Fix https://github.com/eclipse-zenoh/zenoh-plugin-dds/actions/runs/27338454307/job/80988571129?pr=731