### PR TITLE
chore: drop cmake 3.31 install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,6 @@ jobs:
         if: startsWith(matrix.os,'ubuntu')
         run: sudo apt-get -y install libacl1-dev
 
-      # cyclors 0.3.x does not compile with cmake 4
-      - name: Install cmake
-        uses: jwlawson/actions-setup-cmake@v2
-        with: 
-          cmake-version: '3.31.x'
-
       - name: Install LLVM toolchain
         if: startsWith(matrix.os,'macos')
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ async-trait = "0.1.66"
 bincode = "1.3.3"
 cdr = "0.2.4"
 clap = "3.2.23"
-cyclors = "=0.3.10"
+cyclors = "0.4.0"
 derivative = "2.2.0"
 flume = "0.11.0"
 futures = "0.3.26"
@@ -51,16 +51,16 @@ tracing = "0.1"
 zenoh = { version = "1.9.0", features = [
   "plugins",
   "unstable",
-], git = "https://github.com/eclipse-zenoh/zenoh.git" , branch = "main" }
-zenoh-config = { version = "1.9.0", default-features = false, git = "https://github.com/eclipse-zenoh/zenoh.git" , branch = "main" }
+], git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
+zenoh-config = { version = "1.9.0", default-features = false, git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 zenoh-ext = { version = "1.9.0", features = [
   "unstable",
-], git = "https://github.com/eclipse-zenoh/zenoh.git" , branch = "main" }
+], git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 zenoh-plugin-dds = { version = "1.9.0", path = "zenoh-plugin-dds/", default-features = false }
 zenoh-plugin-rest = { version = "1.9.0", default-features = false, features = [
   "static_plugin",
-], git = "https://github.com/eclipse-zenoh/zenoh.git" , branch = "main" }
-zenoh-plugin-trait = { version = "1.9.0", default-features = false, git = "https://github.com/eclipse-zenoh/zenoh.git" , branch = "main" }
+], git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
+zenoh-plugin-trait = { version = "1.9.0", default-features = false, git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
cyclors 0.4.0 should be able to be compiled with cmake4

Supersedes https://github.com/eclipse-zenoh/zenoh-plugin-dds/pull/732 and should allow https://github.com/eclipse-zenoh/zenoh-plugin-dds/pull/731 to succeed next time it's updated.